### PR TITLE
Add Inspect AI evaluation recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A collection of guides and examples for building intelligent applications with o
   - [🚀 Getting Started](#-getting-started)
   - [🎁 Models](#-models)
   - [📘 APIs](#-apis)
+  - [🧪 Evaluations](#-evaluations)
   - [🎠 Agents](#-agents)
   - [🔍 RAG](#-rag)
   - [⛓️ Integrations](#️-integrations)
@@ -82,6 +83,12 @@ Access Token Factory using various APIs:
 &nbsp; • &nbsp; [LiteLLM](api/api_litellm.ipynb)
 &nbsp; • &nbsp; [ai-suite](api/api_aisuite.ipynb)
 &nbsp; • &nbsp; [Llama-index](api/api_llamaindex.ipynb)
+
+---
+
+## 🧪 Evaluations
+
+- [Inspect AI smoke evaluation](evaluations/inspect-ai/README.md) — run a small, reproducible evaluation through Token Factory's OpenAI-compatible endpoint
 
 ---
 

--- a/evaluations/inspect-ai/.env.example
+++ b/evaluations/inspect-ai/.env.example
@@ -1,0 +1,3 @@
+# Required Token Factory settings.
+NEBIUS_API_KEY=your_token_factory_api_key
+NEBIUS_MODEL=openai/gpt-oss-120b

--- a/evaluations/inspect-ai/README.md
+++ b/evaluations/inspect-ai/README.md
@@ -1,0 +1,70 @@
+# Evaluate Token Factory models with Inspect AI
+
+This recipe runs a small, reproducible [Inspect AI](https://inspect.aisi.org.uk/) task against the Nebius Token Factory OpenAI-compatible endpoint. It uses Inspect's existing `openai` provider; no Token Factory-specific adapter is needed.
+
+The included smoke task has two fixed samples, temperature zero, and deterministic exact-answer scoring. It is intentionally small enough to check a model or account before starting a larger evaluation.
+
+## Prerequisites
+
+- Python 3.11 or newer
+- A [Token Factory API key](https://tokenfactory.nebius.com/)
+- A current chat-completions model ID from the [model catalog](https://tokenfactory.nebius.com/models)
+
+## Set up
+
+From this directory:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -e .
+```
+
+Copy the example configuration, replace the key if needed, and load it into your shell:
+
+```bash
+cp .env.example .env
+set -a
+source .env
+set +a
+```
+
+`NEBIUS_API_KEY` and `NEBIUS_MODEL` are both required. The example currently uses `openai/gpt-oss-120b`; choose another active chat model if it is not available to your account.
+
+## Run the evaluation
+
+```bash
+python run_eval.py
+```
+
+The runner maps `NEBIUS_API_KEY` to Inspect's `OPENAI_API_KEY`, sets the canonical base URL to `https://api.tokenfactory.nebius.com/v1`, and selects the model as:
+
+```text
+openai/openai/gpt-oss-120b
+└────┘ └──────────────────┘
+Inspect       Token Factory
+provider      model ID
+```
+
+Inspect writes logs to `logs/`. Open the local viewer with:
+
+```bash
+inspect view --log-dir logs
+```
+
+## Chat Completions and Responses API scope
+
+This recipe explicitly sets `responses_api=False`, so Inspect uses Chat Completions. That is the safe default for evaluation flows that may grow into multi-turn tasks.
+
+Do not change this example to `responses_api=True` unless every sample is an independent, stateless first turn. Token Factory's Responses API currently does not support stateful continuation fields such as `previous_response_id`; multi-turn evaluation state should stay in Chat Completions messages.
+
+## Validate without an API key
+
+The tests use Inspect's in-process mock model and make no network requests:
+
+```bash
+python -m pip install -e '.[test]'
+pytest
+```
+
+They verify required configuration, provider/model mapping, the canonical endpoint, the Chat Completions guard, and the complete task/scorer pipeline.

--- a/evaluations/inspect-ai/pyproject.toml
+++ b/evaluations/inspect-ai/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=77"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "token-factory-inspect-eval"
+version = "0.1.0"
+description = "A small Inspect AI evaluation for Nebius Token Factory"
+requires-python = ">=3.11"
+dependencies = [
+  "inspect-ai==0.3.258",
+  "openai>=2.45,<3",
+]
+
+[project.optional-dependencies]
+test = [
+  "pytest>=8.4,<9",
+]
+
+[tool.setuptools]
+py-modules = ["settings", "smoke_eval", "run_eval"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/evaluations/inspect-ai/run_eval.py
+++ b/evaluations/inspect-ai/run_eval.py
@@ -1,0 +1,39 @@
+"""Run the Inspect smoke evaluation against Nebius Token Factory."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from inspect_ai import eval
+
+from settings import TokenFactorySettings
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--log-dir",
+        default="logs",
+        help="Directory for Inspect evaluation logs (default: logs)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    settings = TokenFactorySettings.from_env()
+    settings.configure_openai_provider()
+
+    logs = eval(
+        "smoke_eval.py",
+        model=settings.inspect_model,
+        model_args={"responses_api": False},
+        log_dir=str(Path(args.log_dir)),
+        display="full",
+    )
+    return 0 if logs and all(log.status == "success" for log in logs) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evaluations/inspect-ai/settings.py
+++ b/evaluations/inspect-ai/settings.py
@@ -1,0 +1,46 @@
+"""Validated runtime settings for the Token Factory Inspect example."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+TOKEN_FACTORY_BASE_URL = "https://api.tokenfactory.nebius.com/v1"
+
+
+@dataclass(frozen=True)
+class TokenFactorySettings:
+    """The required Token Factory values and their Inspect representation."""
+
+    api_key: str
+    model_id: str
+
+    @classmethod
+    def from_env(cls, environ: Mapping[str, str] | None = None) -> TokenFactorySettings:
+        values = os.environ if environ is None else environ
+        missing = [
+            name
+            for name in ("NEBIUS_API_KEY", "NEBIUS_MODEL")
+            if not values.get(name, "").strip()
+        ]
+        if missing:
+            names = ", ".join(missing)
+            raise RuntimeError(f"Missing required environment variable(s): {names}")
+
+        return cls(
+            api_key=values["NEBIUS_API_KEY"].strip(),
+            model_id=values["NEBIUS_MODEL"].strip(),
+        )
+
+    @property
+    def inspect_model(self) -> str:
+        """Select Inspect's generic OpenAI provider without changing the model ID."""
+
+        return f"openai/{self.model_id}"
+
+    def configure_openai_provider(self) -> None:
+        """Map Token Factory credentials to Inspect's OpenAI provider variables."""
+
+        os.environ["OPENAI_API_KEY"] = self.api_key
+        os.environ["OPENAI_BASE_URL"] = TOKEN_FACTORY_BASE_URL

--- a/evaluations/inspect-ai/smoke_eval.py
+++ b/evaluations/inspect-ai/smoke_eval.py
@@ -1,0 +1,33 @@
+"""A tiny deterministic smoke task for Token Factory model evaluations."""
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.model import GenerateConfig
+from inspect_ai.scorer import match
+from inspect_ai.solver import generate, system_message
+
+
+@task
+def token_factory_smoke() -> Task:
+    """Check two simple outputs with a deterministic dataset and scorer."""
+
+    return Task(
+        dataset=[
+            Sample(
+                id="addition",
+                input="What is 19 + 23? Return only the integer.",
+                target="42",
+            ),
+            Sample(
+                id="lowercase",
+                input='Return the words "TOKEN FACTORY" in lowercase and nothing else.',
+                target="token factory",
+            ),
+        ],
+        solver=[
+            system_message("Follow the requested output format exactly."),
+            generate(),
+        ],
+        scorer=match(location="exact", ignore_case=False),
+        config=GenerateConfig(temperature=0),
+    )

--- a/evaluations/inspect-ai/tests/test_recipe.py
+++ b/evaluations/inspect-ai/tests/test_recipe.py
@@ -1,0 +1,75 @@
+"""Offline tests for the Token Factory Inspect recipe."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+from inspect_ai import eval
+from inspect_ai.model import Model, ModelOutput, get_model
+
+from settings import TOKEN_FACTORY_BASE_URL, TokenFactorySettings
+from smoke_eval import token_factory_smoke
+
+
+def test_settings_require_both_token_factory_values() -> None:
+    with pytest.raises(RuntimeError, match="NEBIUS_API_KEY, NEBIUS_MODEL"):
+        TokenFactorySettings.from_env({})
+
+
+def test_settings_select_generic_openai_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    settings = TokenFactorySettings.from_env(
+        {
+            "NEBIUS_API_KEY": "test-key",
+            "NEBIUS_MODEL": "openai/gpt-oss-120b",
+        }
+    )
+
+    settings.configure_openai_provider()
+
+    assert settings.inspect_model == "openai/openai/gpt-oss-120b"
+    assert TOKEN_FACTORY_BASE_URL == "https://api.tokenfactory.nebius.com/v1"
+    assert os.environ["OPENAI_API_KEY"] == "test-key"
+    assert os.environ["OPENAI_BASE_URL"] == TOKEN_FACTORY_BASE_URL
+
+
+def test_task_runs_and_scores_offline(tmp_path: Path) -> None:
+    def deterministic_output(input, tools, tool_choice, config):
+        prompt = input[-1].text
+        answer = "42" if "19 + 23" in prompt else "token factory"
+        return ModelOutput.from_content("mockllm/model", answer)
+
+    model = get_model("mockllm/model", custom_outputs=deterministic_output)
+    logs = eval(
+        token_factory_smoke(),
+        model=model,
+        log_dir=str(tmp_path),
+        display="none",
+    )
+
+    assert len(logs) == 1
+    assert logs[0].status == "success"
+    assert logs[0].results is not None
+    assert logs[0].results.scores[0].metrics["accuracy"].value == 1.0
+
+
+def test_openai_provider_constructs_without_a_custom_adapter() -> None:
+    settings = TokenFactorySettings("offline-test-key", "openai/gpt-oss-120b")
+    settings.configure_openai_provider()
+
+    model: Model = get_model(settings.inspect_model, responses_api=False)
+
+    assert model.api.model_name == "openai/gpt-oss-120b"
+    assert str(model.api.client.base_url).rstrip("/") == TOKEN_FACTORY_BASE_URL
+    assert model.api.responses_api is False
+
+
+def test_recipe_keeps_responses_api_disabled() -> None:
+    runner = Path(__file__).parents[1].joinpath("run_eval.py").read_text()
+    assert '"responses_api": False' in runner
+    assert "responses_api=True" not in runner


### PR DESCRIPTION
## What

- add a standalone Inspect AI smoke evaluation for Token Factory
- configure Inspect through its existing generic OpenAI provider and the canonical Token Factory endpoint
- require `NEBIUS_API_KEY` and `NEBIUS_MODEL`, with `openai/gpt-oss-120b` as the current example
- keep Chat Completions explicit with `responses_api=False`
- add offline configuration, provider-construction, and full mock-eval tests

## Why

Inspect already provides the adapter needed for Token Factory, but the cookbook does not show how to map Token Factory credentials and slash-qualified model IDs into Inspect. A recipe fills that gap without introducing or maintaining a duplicate native provider.

This is a standalone evaluations contribution and does not overlap the API lifecycle/Responses files changed by draft PR #35.

## Impact

Users can run a two-sample deterministic smoke task before moving to larger evaluations. No core provider, production API, or existing example behavior changes. The optional Responses path is deliberately excluded from the runner because it is only appropriate for explicitly stateless, independent first-turn samples.

## Validation

- `pytest -q` — 5 passed
- `ruff check settings.py smoke_eval.py run_eval.py tests`
- `ruff format --check settings.py smoke_eval.py run_eval.py tests`
- `inspect list tasks smoke_eval.py`
- `python -m compileall -q settings.py smoke_eval.py run_eval.py tests`
- `git diff --check`

## AI assistance

This contribution was prepared with Codex assistance and reviewed locally through the checks above.