### PR TITLE
Fix Google ADK Token Factory configuration

### DIFF
--- a/agents/google-adk-tool-calling/README.md
+++ b/agents/google-adk-tool-calling/README.md
@@ -1,154 +1,81 @@
-# Simple Tool Calling Agent with Google ADK (Agent Development Kit) + Nebius AI
+# Google ADK tool-calling agent with Token Factory
 
-![banner](./banner.png)
-
-
-This example shows a sample 'tool calling' agent, built using Google's Agent Development Kit (ADK) framework.
-
-## References
-
-- [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/)
-
+This example connects [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/) to Nebius Token Factory through ADK's `LiteLlm` model wrapper. It demonstrates a small currency-conversion tool agent without adding a native ADK provider.
 
 ## Prerequisites
 
-- Nebius API key (get it from [Nebius Token Factory](http://tokenfactory.nebius.com/))
-- Python 3.10 or higher dev environment.
-
+- Python 3.12 or later
+- A [Token Factory API key](https://tokenfactory.nebius.com/)
+- A current tool-capable model ID from the [public model catalog](https://tokenfactory.nebius.com/api/public/models_info)
 
 ## Setup
 
-**1 - get the code**
-
 ```bash
-git   clone    https://github.com/nebius/token-factory-cookbook/
-cd  agents/google-adk-tool-calling
-```
-**2 - Install dependencies**
-
-using `uv`
-
-```bash
-# create a venv and install dependencies
-uv  sync
-source   .venv/bin/activate
-
-# Verify ADK installation
-adk --version
+git clone https://github.com/nebius/token-factory-cookbook.git
+cd token-factory-cookbook/agents/google-adk-tool-calling
+cp env.sample .env
 ```
 
-Or install using python pip
+Set both required values in `.env`:
+
+```dotenv
+NEBIUS_API_KEY=your_nebius_api_key_here
+NEBIUS_MODEL=moonshotai/Kimi-K2.7-Code
+```
+
+The suggested model was current and advertised function calling when this example was updated on August 13, 2026. `NEBIUS_MODEL` is required so the example does not silently keep using that ID after the public catalog changes.
+
+Install with `uv`:
 
 ```bash
+uv sync
+```
+
+Or with `pip`:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
-
-# Verify ADK installation
-adk --version
 ```
 
-**3 - Create .env file**
+## Run
 
-Create a `.env` file in the project root and add your Nebius API key:
+From this directory:
 
 ```bash
-cp env.example .env
+uv run adk run .
 ```
 
-```text
-NEBIUS_API_KEY=your_api_key_here
+If you used `pip`, activate the virtual environment and run `adk run .` instead. Try:
+
+> Convert 100 USD to EUR.
+
+The agent calls `convert_to_currency` and uses its result in the answer. The conversion rate is fixed test data for demonstrating tool use, not a financial quote.
+
+## Connection details
+
+`config.py` passes all connection settings directly to ADK's `LiteLlm` wrapper:
+
+```python
+{
+    "model": f"openai/{model_id}",
+    "api_base": "https://api.tokenfactory.nebius.com/v1",
+    "api_key": api_key,
+}
 ```
 
+The `openai/` prefix selects LiteLLM's generic OpenAI-compatible Chat Completions route. The Token Factory model ID follows the prefix unchanged. This example does not add an ADK provider or use stateful Responses API behavior.
 
-## Running the agent in CLI
+## Offline validation
 
-Switch to project dir:
+The configuration tests do not contact Token Factory or require credentials:
 
 ```bash
-cd  agents/google-adk-tool-calling
+python -m unittest test_config.py -v
+python -m compileall -q agent.py config.py test_config.py
 ```
 
-**Using `uv`**
+## ADK web UI
 
-```bash
-uv  sync
-uv  run   adk run .
-```
-
-or 
-
-```bash
-uv sync
-source   .venv/bin/activate
-adk run .
-```
-
-**Using python pip**
-
-```bash
-adk run .
-```
-
-## Interacting with the Agent
-
-Once the agent is running, we can try the following:
-
-**Find out what the agent can do**
-
-> What are your capabilities?
-
-> What can you do?
-
-**Ask the agent questions**
-
-> What is $100 in EUR?
-
-You should get answer like 
-
-`The converted amount is 200 EUR`
-
-Ask another:
-
-> Convert $100 into AUD
-
-Since the agent can only convert from USD --> EUR, you may get an answer like this
-
-`I currently only support converting USD to EUR (Euro). Conversion to AUD (Australian Dollar) isn't available yet`
-
-## ADK UI Runner
-
-ADK has a [web ui](https://google.github.io/adk-docs/get-started/quickstart/#dev-ui-adk-web) that can show you details of agent's inner working.  This is a great tool for debugging.
-
-![](adk-web-1.png)
-
-Here is how to run the web ui.
-
-**Go to parent dir** (This is important!)
-
-```bash
-# go project's parent directory
-cd ..  
-
-# and run
-adk web
-```
-
-Go to URL : [localhost:8000](http://localhost:8000/)
-
-**Select the agent from drop down list**
-
-**And interact with the agent**
-
-**Look at `Trace` and `Events` tabs**
-
-
-## Dev Notes
-
-**Preparing the dev env using UV**
-
-```bash
-cd google-adk-tool-calling
-uv init .
-mv main.py   agent.py
-uv  add -r requirements.txt
-uv sync
-```
+To use the development UI, run `adk web` from the parent `agents` directory, then select `google-adk-tool-calling` at [localhost:8000](http://localhost:8000/).

--- a/agents/google-adk-tool-calling/agent.py
+++ b/agents/google-adk-tool-calling/agent.py
@@ -1,61 +1,33 @@
+from dotenv import load_dotenv
 from google.adk.agents import Agent
 from google.adk.models.lite_llm import LiteLlm
-from dotenv import load_dotenv
+
+from .config import load_token_factory_config
 
 
-load_dotenv() # load settings from .env file
-
-def convert_to_currency(currency: str, amount: float) -> float:
-    """
-    Converts a given amount in USD to the specified currency.
-    Currently, only conversion to EUR is supported.
-    It is just a placeholder for demonstration purposes.
-
-    Args:
-        currency (str): The target currency code. Only 'EUR' is supported.
-        amount (float): The amount in USD to convert.
-    
-    Returns:
-        dict: If the currency is supported, returns a dict with status 'success' and the converted amount.
-              If the currency is not supported, returns a dict with status 'error' and an error message.
-    """
-
-    if currency.lower() == 'eur':
+def convert_to_currency(currency: str, amount: float) -> dict[str, str | float]:
+    """Convert a USD amount to EUR for this tool-calling demonstration."""
+    if currency.upper() == "EUR":
         return {
             "status": "success",
-            "amount": amount * 2,
+            "amount": amount * 0.86,
+            "currency": "EUR",
         }
-    else:
-        return {
-            "status": "error",
-            "error_message": f"conversion for currency '{currency}' is not available.",
-        }
-## -----end : convert_to_currency ---------
+    return {
+        "status": "error",
+        "error_message": f"Conversion to {currency.upper()} is not available.",
+    }
 
 
+load_dotenv()
+token_factory = load_token_factory_config()
 
-llm = LiteLlm(
-    ## Choose a model from the list of available models in the Nebius Token Factory
-    model="nebius/openai/gpt-oss-120b",
-    # model="nebius/meta-llama/Llama-3.3-70B-Instruct",
-    # model="nebius/deepseek-ai/DeepSeek-V4-Pro",
-    # model="nebius/Qwen/Qwen3-235B-A22B",
-    
-    ## other settings you may want to use
-    # temperature=0.1,
-    # max_tokens=1000,
-    # top_p=0.95,
-    # top_k=40,
-)
+llm = LiteLlm(**token_factory.litellm_kwargs())
 
 root_agent = Agent(
     name="currency_agent",
-    model= llm,
-    description=(
-        "Agent to convert USD to other currencies. "
-    ),
-    instruction=(
-        "You are a helpful agent who can convert USD to other currency amounts."
-    ),
+    model=llm,
+    description="Converts USD amounts to supported currencies.",
+    instruction="Use the currency conversion tool for every conversion request.",
     tools=[convert_to_currency],
 )

--- a/agents/google-adk-tool-calling/config.py
+++ b/agents/google-adk-tool-calling/config.py
@@ -1,0 +1,38 @@
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+TOKEN_FACTORY_API_BASE = "https://api.tokenfactory.nebius.com/v1"
+
+
+@dataclass(frozen=True)
+class TokenFactoryConfig:
+    api_key: str
+    model_id: str
+
+    def litellm_kwargs(self) -> dict[str, str]:
+        return {
+            "model": f"openai/{self.model_id}",
+            "api_base": TOKEN_FACTORY_API_BASE,
+            "api_key": self.api_key,
+        }
+
+
+def load_token_factory_config(
+    environment: Mapping[str, str] | None = None,
+) -> TokenFactoryConfig:
+    source = os.environ if environment is None else environment
+    api_key = source.get("NEBIUS_API_KEY", "").strip()
+    model_id = source.get("NEBIUS_MODEL", "").strip()
+
+    missing = [
+        name
+        for name, value in (("NEBIUS_API_KEY", api_key), ("NEBIUS_MODEL", model_id))
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Missing required environment variable(s): {', '.join(missing)}"
+        )
+
+    return TokenFactoryConfig(api_key=api_key, model_id=model_id)

--- a/agents/google-adk-tool-calling/env.sample
+++ b/agents/google-adk-tool-calling/env.sample
@@ -1,2 +1,2 @@
 NEBIUS_API_KEY=your_nebius_api_key_here
-
+NEBIUS_MODEL=moonshotai/Kimi-K2.7-Code

--- a/agents/google-adk-tool-calling/test_config.py
+++ b/agents/google-adk-tool-calling/test_config.py
@@ -1,0 +1,33 @@
+import unittest
+
+from config import TOKEN_FACTORY_API_BASE, load_token_factory_config
+
+
+class TokenFactoryConfigTest(unittest.TestCase):
+    def test_builds_explicit_openai_compatible_litellm_settings(self) -> None:
+        config = load_token_factory_config(
+            {
+                "NEBIUS_API_KEY": "test-key",
+                "NEBIUS_MODEL": "moonshotai/Kimi-K2.7-Code",
+            }
+        )
+
+        self.assertEqual(
+            config.litellm_kwargs(),
+            {
+                "model": "openai/moonshotai/Kimi-K2.7-Code",
+                "api_base": TOKEN_FACTORY_API_BASE,
+                "api_key": "test-key",
+            },
+        )
+
+    def test_requires_key_and_model(self) -> None:
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "NEBIUS_API_KEY, NEBIUS_MODEL",
+        ):
+            load_token_factory_config({})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- route the existing Google ADK example through LiteLLM's generic OpenAI-compatible path
- pass Token Factory's canonical `api_base`, `NEBIUS_API_KEY`, and required `NEBIUS_MODEL` explicitly to ADK's `LiteLlm` wrapper
- keep the model ID unchanged after LiteLLM's `openai/` routing prefix
- retain a small currency tool agent while tightening types and simplifying the example
- add offline unit tests for configuration mapping and missing environment variables
- document setup, connection semantics, catalog freshness, and the Chat Completions-only scope

## Why

The prior example used LiteLLM's `nebius/<model>` shorthand and a hard-coded model. That hid the connection contract and made the recipe depend on provider-specific LiteLLM behavior.

LiteLLM's documented custom OpenAI-compatible route accepts `model="openai/<model>"`, `api_base`, and `api_key`. Passing those values through ADK's `LiteLlm` wrapper keeps this a generic integration and avoids adding a Google ADK provider or adapter.

`moonshotai/Kimi-K2.7-Code` was verified in Token Factory's public catalog on August 13, 2026 and advertised function calling. Runtime configuration still requires `NEBIUS_MODEL` so future catalog changes do not require a source edit.

This PR does not overlap #35 or #38; neither touches `agents/google-adk-tool-calling`.

## Validation

From `agents/google-adk-tool-calling`:

- `python3 -m unittest test_config.py -v` — 2 passed
- `python3 -m compileall -q agent.py config.py test_config.py` — passed
- `uvx ruff check agent.py config.py test_config.py` — passed
- `uvx ruff format --check agent.py config.py test_config.py` — passed
- `git diff --check` — passed

No Token Factory credential was available, so this PR does not claim a paid live inference run.

## API scope

This is an OpenAI-compatible Chat Completions recipe. It does not use response persistence, continuation IDs, or other stateful Responses API behavior.
