### PR TITLE
Add pi coding agent setup recipe

### DIFF
--- a/integrations/pi/README.md
+++ b/integrations/pi/README.md
@@ -1,0 +1,88 @@
+# pi coding agent + Nebius Token Factory
+
+[pi](https://github.com/earendil-works/pi) is a terminal coding agent with a built-in custom-provider configuration path. Nebius Token Factory works through pi's existing `openai-completions` API mode, so no provider adapter or extension is required.
+
+This recipe uses OpenAI-compatible Chat Completions. It does not select pi's separate `openai-responses` mode.
+
+## Prerequisites
+
+- Node.js and the [pi coding agent](https://www.npmjs.com/package/@earendil-works/pi-coding-agent).
+- A Nebius Token Factory API key from [tokenfactory.nebius.com](https://tokenfactory.nebius.com/).
+- A model available to your Token Factory account. The sample uses the current `zai-org/GLM-5.1`; verify it, or choose another tool-capable model, in the [live model catalog](https://tokenfactory.nebius.com/model-catalog.md).
+
+## 1. Install pi
+
+```bash
+npm install -g --ignore-scripts @earendil-works/pi-coding-agent
+```
+
+## 2. Configure the provider
+
+Pi reads custom providers from `~/.pi/agent/models.json`. On a fresh setup, copy [`models.example.json`](models.example.json) there. If the file already exists, merge the `nebius-token-factory` entry into its existing `providers` object instead of replacing the file.
+
+```bash
+mkdir -p ~/.pi/agent
+cp models.example.json ~/.pi/agent/models.json
+```
+
+The important fields are:
+
+- `baseUrl`: Token Factory's canonical API root, including `/v1`.
+- `apiKey`: `$NEBIUS_API_KEY`, which tells pi to resolve the environment variable at request time. Do not remove the `$`.
+- `api`: `openai-completions`, pi's Chat Completions compatibility mode.
+- `models`: explicit model entries; pi does not copy Token Factory's catalog into this local file automatically.
+
+The compatibility overrides keep the baseline request aligned with Token Factory's Chat Completions schema: use `system` rather than `developer`, send `max_tokens` rather than `max_completion_tokens`, and do not request OpenAI long-cache retention.
+
+## 3. Set the API key
+
+```bash
+export NEBIUS_API_KEY=your_key_here
+```
+
+Keep the key in your shell or secret manager. Do not paste a working key into `models.json` or commit one to source control.
+
+## 4. Select the model
+
+Confirm pi loaded the custom entry:
+
+```bash
+pi --list-models "GLM-5.1"
+```
+
+Then start pi in the project you want it to work on:
+
+```bash
+pi --provider nebius-token-factory --model zai-org/GLM-5.1
+```
+
+You can also select the model from `/model` in an interactive pi session.
+
+The sample keeps pi's extended-thinking controls off and declares text input only. That is the conservative coding-agent baseline validated by this recipe. Tool calling remains available because pi's normal coding tools use the Chat Completions `tools` field. Enable model-specific reasoning controls or image input only after validating the exact current model and route.
+
+## Validate the sample offline
+
+The included test checks the provider schema, canonical URL, environment-key reference, current model entry, compatibility overrides, and absence of Responses mode without making an API request:
+
+```bash
+cd integrations/pi
+python3 -m unittest -v test_recipe.py
+```
+
+## Troubleshooting
+
+- **Model does not appear** — ensure the file is exactly `~/.pi/agent/models.json`, export `NEBIUS_API_KEY` in the shell that starts pi, then reopen `/model`. Pi reloads the file when the model selector opens.
+- **Authentication error** — the JSON value must be `"$NEBIUS_API_KEY"`, including the `$`. `"NEBIUS_API_KEY"` is treated as a literal key.
+- **404 / model not found** — compare the exact, case-sensitive model ID with the live catalog and the models available to your key. Update the single model entry rather than copying a static catalog.
+- **Request mentions `developer` or `max_completion_tokens`** — confirm the `compat` object from the sample is present and nested under `nebius-token-factory`.
+- **Wrong endpoint** — use `https://api.tokenfactory.nebius.com/v1`. Do not append `/chat/completions`; pi adds the route.
+- **Tool calls fail** — first test a plain prompt, then verify that the selected model currently advertises function calling. Tool support is model-specific even when the API route is compatible.
+- **Context or cost display looks wrong** — model metadata changes over time. Recheck the live catalog before changing `contextWindow`; pi's cost display is zero unless you add current rates, so use Token Factory billing as the source of truth.
+- **You need Responses-specific features** — this recipe intentionally uses Chat Completions. Token Factory's Responses-compatible surface is stateless and requires separate model/workflow validation; changing `api` is not a drop-in persistence guarantee.
+
+## Resources
+
+- [pi custom models documentation](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/models.md)
+- [pi provider documentation](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/providers.md)
+- [Token Factory model catalog](https://tokenfactory.nebius.com/model-catalog.md)
+- [Token Factory Chat Completions API](https://docs.tokenfactory.nebius.com/api-reference/inference/chat-completion)

--- a/integrations/pi/models.example.json
+++ b/integrations/pi/models.example.json
@@ -1,0 +1,25 @@
+{
+  "providers": {
+    "nebius-token-factory": {
+      "name": "Nebius Token Factory",
+      "baseUrl": "https://api.tokenfactory.nebius.com/v1",
+      "apiKey": "$NEBIUS_API_KEY",
+      "api": "openai-completions",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false,
+        "maxTokensField": "max_tokens",
+        "supportsLongCacheRetention": false
+      },
+      "models": [
+        {
+          "id": "zai-org/GLM-5.1",
+          "name": "GLM-5.1 (Nebius Token Factory)",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 200000
+        }
+      ]
+    }
+  }
+}

--- a/integrations/pi/test_recipe.py
+++ b/integrations/pi/test_recipe.py
@@ -1,0 +1,50 @@
+"""Offline checks for the pi coding-agent configuration recipe."""
+
+import json
+import unittest
+from pathlib import Path
+from urllib.parse import urlparse
+
+RECIPE_DIR = Path(__file__).parent
+CONFIG_PATH = RECIPE_DIR / "models.example.json"
+
+
+class PiRecipeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.config = json.loads(CONFIG_PATH.read_text(encoding="utf-8"))
+        cls.provider = cls.config["providers"]["nebius-token-factory"]
+
+    def test_uses_chat_completions_and_canonical_url(self):
+        self.assertEqual(self.provider["api"], "openai-completions")
+        self.assertNotIn("openai-responses", CONFIG_PATH.read_text(encoding="utf-8"))
+        parsed = urlparse(self.provider["baseUrl"])
+        self.assertEqual(parsed.scheme, "https")
+        self.assertEqual(parsed.netloc, "api.tokenfactory.nebius.com")
+        self.assertEqual(parsed.path, "/v1")
+
+    def test_requires_environment_key_reference(self):
+        self.assertEqual(self.provider["apiKey"], "$NEBIUS_API_KEY")
+
+    def test_pins_safe_chat_compatibility_fields(self):
+        self.assertEqual(
+            self.provider["compat"],
+            {
+                "supportsDeveloperRole": False,
+                "supportsReasoningEffort": False,
+                "maxTokensField": "max_tokens",
+                "supportsLongCacheRetention": False,
+            },
+        )
+
+    def test_defines_one_explicit_current_model(self):
+        self.assertEqual(len(self.provider["models"]), 1)
+        model = self.provider["models"][0]
+        self.assertEqual(model["id"], "zai-org/GLM-5.1")
+        self.assertIs(model["reasoning"], False)
+        self.assertEqual(model["input"], ["text"])
+        self.assertGreater(model["contextWindow"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a first-party pi coding-agent recipe using its existing `models.json` custom-provider path
- configure Token Factory through `openai-completions` with the canonical URL and an environment-resolved API key
- include a current explicit model, conservative compatibility overrides, troubleshooting, and an offline validator

No pi provider adapter, extension, or copied model catalog is introduced.

## Why

Pi already supports custom OpenAI-compatible providers through `baseUrl`, `apiKey`, `api`, and explicit model entries. A cookbook recipe is the appropriate owner path; provider code in pi would duplicate that built-in mechanism.

The compatibility fields reflect Token Factory's current Chat Completions schema: no `developer` role, `max_tokens` instead of `max_completion_tokens`, and no unvalidated long-cache-retention behavior. Responses mode and extended-thinking controls remain out of this baseline.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest -v test_recipe.py` — 4 passed
- `python3 -m json.tool models.example.json`
- `uvx ruff check test_recipe.py`
- `uvx ruff format --check test_recipe.py`
- installed released pi `0.84.1` with lifecycle scripts disabled and loaded the sample via `PI_CODING_AGENT_DIR`; `pi --list-models GLM-5.1` reported the custom provider/model with a 200K context
- verified `zai-org/GLM-5.1` against the public Token Factory catalog on 2026-08-13
- reviewed pi's current custom-model docs, TypeBox `models.json` schema, API compatibility resolution, and contribution policy at repository head `6f707eb3`

## Scope note

This PR adds only `integrations/pi/`. Other open cookbook PRs edit the integration indexes, so leaving those files untouched keeps this change independent and file-disjoint.
