### PR TITLE
Add Cherry Studio Token Factory setup recipe

### DIFF
--- a/coding/cherry-studio/README.md
+++ b/coding/cherry-studio/README.md
@@ -1,0 +1,106 @@
+# Cherry Studio with Nebius Token Factory
+
+Cherry Studio already supports custom OpenAI-compatible providers. This recipe configures its existing **OpenAI Chat Completions** endpoint for Token Factory. It does not add a provider adapter or enable stateful Responses behavior.
+
+Cherry Studio stores custom providers in its application database, so [`config.json`](config.json) is a reviewable reference manifest—not a file to import into the application. Follow the UI steps below.
+
+## Prerequisites
+
+- [Cherry Studio](https://github.com/CherryHQ/cherry-studio) installed
+- a [Token Factory API key](https://tokenfactory.nebius.com/project/api-keys)
+
+## Add the provider
+
+1. Open **Settings → Model Services**.
+2. Select **Add Provider** (`+`), then **Add Custom Provider**.
+3. Enter:
+
+   | Field                              | Value                                    |
+   | ---------------------------------- | ---------------------------------------- |
+   | Provider name                      | `Nebius Token Factory`                   |
+   | API key                            | Your Token Factory key                   |
+   | OpenAI / Chat Completions Base URL | `https://api.tokenfactory.nebius.com/v1` |
+
+4. Keep **OpenAI / Chat Completions** selected as the default text endpoint.
+5. Leave **OpenAI Responses** under **More Endpoints** empty. Token Factory's current Responses surface is stateless Stage 1 and is not the default wire contract for this recipe.
+6. Save the provider.
+
+Cherry Studio previews the final Chat Completions request as:
+
+```text
+https://api.tokenfactory.nebius.com/v1/chat/completions
+```
+
+Do not paste the full `/chat/completions` path into the Base URL field; Cherry Studio appends it.
+
+## Discover and add models
+
+1. Select the new **Nebius Token Factory** provider.
+2. Choose **Get model list** / **Pull models**.
+3. Cherry Studio calls `GET https://api.tokenfactory.nebius.com/v1/models` with the configured bearer key.
+4. Select a current coding model and apply the changes. This recipe was checked with `moonshotai/Kimi-K2.7-Code`.
+5. If you add the model manually instead, use the exact raw model ID and set its chat protocol/endpoint type to **OpenAI Chat Completions**. Do not prepend `openai/` or `nebius/`.
+6. Enable the provider, choose the model in a chat, and send a small prompt.
+
+Model availability changes independently of Cherry Studio. Prefer **Get model list** over copying a static catalog, and re-pull before relying on a model in a durable workflow.
+
+## Scope
+
+This setup covers Token Factory's OpenAI-compatible Chat Completions path, including normal Cherry Studio chat and model features supported by the selected model.
+
+It deliberately does not configure Cherry Studio's separate **OpenAI Responses** endpoint. Do not infer support for `previous_response_id`, server-side conversation chaining, or replay of prior response output/reasoning items from Cherry Studio's ability to speak that protocol to other providers.
+
+## Validate the reference offline
+
+The reference manifest contains no API key. Validate it with Node's built-in tools:
+
+```bash
+node validate-config.mjs
+node --test validate-config.test.mjs
+```
+
+The checks make no network calls. They verify the provider name, canonical Base URL, Chat Completions default and model endpoint, derived `/chat/completions` and `/models` routes, raw model ID, absence of a Responses endpoint, and absence of stored secrets.
+
+## Troubleshooting
+
+### 401 Unauthorized
+
+Open the provider's authentication section and replace the API key with a current Token Factory key. A key is stored by Cherry Studio locally; never add it to `config.json`, source control, screenshots, or support logs.
+
+### 404 or wrong host
+
+The Base URL must be exactly `https://api.tokenfactory.nebius.com/v1`. Retired `api.studio.nebius.*` hosts are not valid. Do not omit `/v1`, and do not append `/chat/completions` or `/models` yourself.
+
+### Get model list fails
+
+Confirm the provider has an enabled API key and the Chat Completions Base URL is set. The generic Cherry Studio model fetcher derives `/models` from that Base URL and sends bearer authentication. You can compare the upstream response directly:
+
+```bash
+curl -sS https://api.tokenfactory.nebius.com/v1/models \
+  -H "Authorization: Bearer $NEBIUS_API_KEY"
+```
+
+### Model not found
+
+Pull the model list again. If the model was removed, select another current model suitable for coding and tool use. Keep the provider-owned model ID unchanged.
+
+### Requests unexpectedly use Responses
+
+Edit the provider and confirm **OpenAI / Chat Completions** is the default endpoint. Remove any OpenAI Responses Base URL, then edit the model and ensure its endpoint type contains only **OpenAI Chat Completions**.
+
+## Evidence checked
+
+The recipe follows Cherry Studio's current public source behavior:
+
+- custom providers expose independent OpenAI Chat Completions and OpenAI Responses URL fields;
+- Chat Completions is the default when it is the configured text endpoint;
+- request previews append `/chat/completions` to the configured API root; and
+- the generic model fetcher appends `/models` and sends bearer authentication.
+
+No Cherry Studio provider preset or adapter is required.
+
+## References
+
+- [Cherry Studio repository](https://github.com/CherryHQ/cherry-studio)
+- [Token Factory inference quickstart](https://docs.tokenfactory.nebius.com/inference/quickstart)
+- [Token Factory API reference](https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion)

--- a/coding/cherry-studio/config.json
+++ b/coding/cherry-studio/config.json
@@ -1,0 +1,14 @@
+{
+  "providerName": "Nebius Token Factory",
+  "defaultChatEndpoint": "openai-chat-completions",
+  "endpointConfigs": {
+    "openai-chat-completions": {
+      "baseUrl": "https://api.tokenfactory.nebius.com/v1"
+    }
+  },
+  "model": {
+    "id": "moonshotai/Kimi-K2.7-Code",
+    "name": "Kimi K2.7 Code",
+    "endpointTypes": ["openai-chat-completions"]
+  }
+}

--- a/coding/cherry-studio/validate-config.mjs
+++ b/coding/cherry-studio/validate-config.mjs
@@ -1,0 +1,76 @@
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+const BASE_URL = "https://api.tokenfactory.nebius.com/v1";
+const CHAT_ENDPOINT = "openai-chat-completions";
+
+export function deriveRoutes(config) {
+  const baseUrl = config.endpointConfigs?.[CHAT_ENDPOINT]?.baseUrl?.replace(
+    /\/+$/,
+    "",
+  );
+  return {
+    chatCompletions: baseUrl ? `${baseUrl}/chat/completions` : "",
+    models: baseUrl ? `${baseUrl}/models` : "",
+  };
+}
+
+export function validateConfig(config) {
+  const errors = [];
+  const endpoint = config.endpointConfigs?.[CHAT_ENDPOINT];
+
+  if (config.providerName !== "Nebius Token Factory") {
+    errors.push("providerName must be Nebius Token Factory");
+  }
+  if (config.defaultChatEndpoint !== CHAT_ENDPOINT) {
+    errors.push("defaultChatEndpoint must use OpenAI Chat Completions");
+  }
+  if (endpoint?.baseUrl !== BASE_URL) {
+    errors.push(`Chat Completions baseUrl must be ${BASE_URL}`);
+  }
+  if (
+    Object.keys(config.endpointConfigs ?? {}).some((key) =>
+      key.includes("responses"),
+    )
+  ) {
+    errors.push("do not configure a Responses endpoint in this recipe");
+  }
+  if (!config.model?.id || config.model.id.startsWith("openai/")) {
+    errors.push("model.id must be the raw Token Factory model ID");
+  }
+  if (
+    !Array.isArray(config.model?.endpointTypes) ||
+    config.model.endpointTypes.length !== 1 ||
+    config.model.endpointTypes[0] !== CHAT_ENDPOINT
+  ) {
+    errors.push(
+      "model.endpointTypes must contain only OpenAI Chat Completions",
+    );
+  }
+  if ("apiKey" in config || "apiKeys" in config) {
+    errors.push("do not store API keys in the checked-in manifest");
+  }
+
+  return errors;
+}
+
+async function main() {
+  const config = JSON.parse(
+    await readFile(new URL("./config.json", import.meta.url), "utf8"),
+  );
+  const errors = validateConfig(config);
+
+  if (errors.length > 0) {
+    for (const error of errors) console.error(`- ${error}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const routes = deriveRoutes(config);
+  console.log(`Chat route: ${routes.chatCompletions}`);
+  console.log(`Model discovery: ${routes.models}`);
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  await main();
+}

--- a/coding/cherry-studio/validate-config.test.mjs
+++ b/coding/cherry-studio/validate-config.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { deriveRoutes, validateConfig } from "./validate-config.mjs";
+
+const config = JSON.parse(
+  await readFile(new URL("./config.json", import.meta.url), "utf8"),
+);
+
+test("manifest represents Cherry Studio custom Chat Completions setup", () => {
+  assert.deepEqual(validateConfig(config), []);
+  assert.equal(config.model.id, "moonshotai/Kimi-K2.7-Code");
+  assert.equal(Object.hasOwn(config, "apiKey"), false);
+  assert.equal(Object.hasOwn(config, "apiKeys"), false);
+});
+
+test("canonical base URL produces Cherry Studio request and discovery routes", () => {
+  assert.deepEqual(deriveRoutes(config), {
+    chatCompletions: "https://api.tokenfactory.nebius.com/v1/chat/completions",
+    models: "https://api.tokenfactory.nebius.com/v1/models",
+  });
+});
+
+test("validator rejects Responses, prefixed models, wrong routes, and secrets", () => {
+  const invalid = structuredClone(config);
+  invalid.providerName = "AI Studio";
+  invalid.defaultChatEndpoint = "openai-responses";
+  invalid.endpointConfigs["openai-chat-completions"].baseUrl =
+    "https://api.studio.nebius.ai/v1";
+  invalid.endpointConfigs["openai-responses"] = {
+    baseUrl: "https://api.tokenfactory.nebius.com/v1",
+  };
+  invalid.model.id = "openai/moonshotai/Kimi-K2.7-Code";
+  invalid.model.endpointTypes = ["openai-responses"];
+  invalid.apiKey = "secret";
+
+  assert.deepEqual(validateConfig(invalid), [
+    "providerName must be Nebius Token Factory",
+    "defaultChatEndpoint must use OpenAI Chat Completions",
+    "Chat Completions baseUrl must be https://api.tokenfactory.nebius.com/v1",
+    "do not configure a Responses endpoint in this recipe",
+    "model.id must be the raw Token Factory model ID",
+    "model.endpointTypes must contain only OpenAI Chat Completions",
+    "do not store API keys in the checked-in manifest",
+  ]);
+});


### PR DESCRIPTION
## Summary

- document Cherry Studio's existing OpenAI-compatible custom-provider path for Nebius Token Factory
- keep OpenAI Chat Completions as the default and leave Cherry Studio's separate Responses endpoint unconfigured
- add a secret-free reference manifest plus offline validation for the canonical base URL, derived chat/model routes, raw model ID, and protocol selection

## Why this is recipe-only

Cherry Studio already supports everything this setup needs: independent OpenAI Chat Completions endpoint configuration, bearer-authenticated model discovery from `/models`, and manual model endpoint selection. Its custom-provider state is stored in the application database, so `config.json` is explicitly documented as a reviewable reference—not an import file. No upstream provider adapter or preset is required.

## Validation

- `node validate-config.mjs`
- `node --test validate-config.test.mjs`
- `node --check validate-config.mjs`
- `node --check validate-config.test.mjs`
- `python3 -m json.tool config.json`
- `npx --yes prettier --check README.md config.json validate-config.mjs validate-config.test.mjs`
- `git diff --check`

## Scope guardrail

This recipe does not claim stateful Responses support. It does not configure `previous_response_id`, server-side chaining, or replay of prior response output/reasoning items.
