### PR TITLE
Repair API framework notebooks and dependency isolation

### DIFF
--- a/api/api_aisuite.ipynb
+++ b/api/api_aisuite.ipynb
@@ -13,10 +13,10 @@
         "\n",
         "## References and Acknowledgements\n",
         "\n",
-        "- [API documentation](https://docs.tokenfactory.nebius.com//inference/integrations/aisuite)\n",
+        "- [Token Factory integrations](https://docs.tokenfactory.nebius.com/integrations/overview)\n",
         "- [aisuite](https://github.com/andrewyng/aisuite)\n",
         "\n",
-        "## Pre requisites\n",
+        "## Prerequisites\n",
         "\n",
         "- Nebius API key.  Sign up for free at [Token Factory](https://tokenfactory.nebius.com/)\n",
         "- And complete [the setup](https://github.com/nebius/token-factory-cookbook/blob/main/getting-started.md)\n",
@@ -34,7 +34,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -46,7 +46,7 @@
       "source": [
         "%%capture\n",
         "\n",
-        "!pip install -q openai aisuite  docstring-parser  python-dotenv"
+        "!pip install -q \"aisuite==0.1.14\" \"docstring-parser==0.15\" \"openai>=2.20,<3\" \"python-dotenv>=1,<2\""
       ]
     },
     {
@@ -60,7 +60,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -68,16 +68,7 @@
         "id": "sFSX16IeFLKa",
         "outputId": "40304ba1-036f-4e79-b836-2b706a9a1bcc"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "NOT running in Colab\n",
-            "✅ NEBIUS_API_KEY found\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import os, sys\n",
         "\n",
@@ -98,6 +89,9 @@
         "## quick hack (not recommended) - you can hardcode the config key here\n",
         "# NEBIUS_API_KEY = \"your_key_here\"\n",
         "\n",
+        "NEBIUS_BASE_URL = \"https://api.tokenfactory.nebius.com/v1/\"\n",
+        "NEBIUS_MODEL = os.getenv(\"NEBIUS_MODEL\", \"openai/gpt-oss-120b\").strip()\n",
+        "\n",
         "if NEBIUS_API_KEY:\n",
         "  print ('✅ NEBIUS_API_KEY found')\n",
         "  os.environ['NEBIUS_API_KEY'] = NEBIUS_API_KEY\n",
@@ -114,7 +108,7 @@
         "## 3 - Pick a Model\n",
         "\n",
         "1. Go to **models** tab in [tokenfactory.nebius.com](https://tokenfactory.nebius.com/)\n",
-        "2. Copy the model name.  For example **`openai/gpt-oss-120b-Instruct-2507`**\n",
+        "2. Copy the exact model ID. This notebook defaults to **`openai/gpt-oss-120b`**, which was present in the public catalog on 2026-08-13. Set `NEBIUS_MODEL` to override it if the catalog changes.\n",
         "\n",
         "![](https://raw.githubusercontent.com/nebius/token-factory-cookbook/main/images/token-factory-1-models.png)"
       ]
@@ -128,7 +122,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -136,68 +130,25 @@
         "id": "R8htBO7iH6-e",
         "outputId": "f5280299-a087-4708-c1dc-4c2f5669bf08"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "----model answer -----\n",
-            "The capital of France is Paris.\n",
-            "\n",
-            "----- full response ----\n",
-            "{\n",
-            "  \"id\": \"chatcmpl-ee7a8e79ac83447686508087cde32c70\",\n",
-            "  \"choices\": [\n",
-            "    {\n",
-            "      \"finish_reason\": \"stop\",\n",
-            "      \"index\": 0,\n",
-            "      \"logprobs\": null,\n",
-            "      \"message\": {\n",
-            "        \"content\": \"The capital of France is Paris.\",\n",
-            "        \"refusal\": null,\n",
-            "        \"role\": \"assistant\",\n",
-            "        \"annotations\": null,\n",
-            "        \"audio\": null,\n",
-            "        \"function_call\": null,\n",
-            "        \"tool_calls\": [],\n",
-            "        \"reasoning_content\": null\n",
-            "      },\n",
-            "      \"stop_reason\": null,\n",
-            "      \"token_ids\": null\n",
-            "    }\n",
-            "  ],\n",
-            "  \"created\": 1762231897,\n",
-            "  \"model\": \"openai/gpt-oss-120b-Instruct-2507\",\n",
-            "  \"object\": \"chat.completion\",\n",
-            "  \"service_tier\": null,\n",
-            "  \"system_fingerprint\": null,\n",
-            "  \"usage\": {\n",
-            "    \"completion_tokens\": 8,\n",
-            "    \"prompt_tokens\": 26,\n",
-            "    \"total_tokens\": 34,\n",
-            "    \"completion_tokens_details\": null,\n",
-            "    \"prompt_tokens_details\": null\n",
-            "  },\n",
-            "  \"prompt_logprobs\": null,\n",
-            "  \"prompt_token_ids\": null,\n",
-            "  \"kv_transfer_params\": null\n",
-            "}\n",
-            "---------\n",
-            "CPU times: user 752 ms, sys: 310 ms, total: 1.06 s\n",
-            "Wall time: 5.64 s\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%%time\n",
         "\n",
         "import os\n",
         "import aisuite as ai\n",
         "\n",
-        "client = ai.Client()\n",
+        "# aisuite 0.1.14's built-in `nebius` provider still points at the former\n",
+        "# Studio host. Configure its existing OpenAI-compatible provider instead.\n",
+        "client = ai.Client(\n",
+        "    provider_configs={\n",
+        "        \"openai\": {\n",
+        "            \"api_key\": NEBIUS_API_KEY,\n",
+        "            \"base_url\": NEBIUS_BASE_URL,\n",
+        "        }\n",
+        "    }\n",
+        ")\n",
         "\n",
-        "provider = \"nebius\"\n",
-        "model_id = \"openai/gpt-oss-120b-Instruct-2507\"\n",
+        "provider = \"openai\"\n",
         "\n",
         "messages = [\n",
         "    {\n",
@@ -211,7 +162,7 @@
         "]\n",
         "\n",
         "response = client.chat.completions.create(\n",
-        "    model=f\"{provider}:{model_id}\",\n",
+        "    model=f\"{provider}:{NEBIUS_MODEL}\",\n",
         "    messages=messages,\n",
         ")\n",
         "\n",

--- a/api/api_litellm.ipynb
+++ b/api/api_litellm.ipynb
@@ -16,7 +16,7 @@
         "- [LiteLLM documentation](https://docs.litellm.ai/)\n",
         "- [LiteLLM + nebius API examples](https://docs.litellm.ai/docs/providers/nebius)\n",
         "\n",
-        "## Pre requisites\n",
+        "## Prerequisites\n",
         "\n",
         "- Nebius API key.  Sign up for free at [Token Factory](https://tokenfactory.nebius.com/)\n",
         "- And complete [the setup](https://github.com/nebius/token-factory-cookbook/blob/main/getting-started.md)\n",
@@ -34,7 +34,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 1,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -46,7 +46,7 @@
       "source": [
         "%%capture\n",
         "\n",
-        "!pip install -q litellm  python-dotenv"
+        "!pip install -q \"litellm==1.96.2\" \"python-dotenv>=1,<2\""
       ]
     },
     {
@@ -60,7 +60,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -68,16 +68,7 @@
         "id": "sFSX16IeFLKa",
         "outputId": "40304ba1-036f-4e79-b836-2b706a9a1bcc"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "NOT running in Colab\n",
-            "✅ NEBIUS_API_KEY found\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import os, sys\n",
         "\n",
@@ -98,6 +89,9 @@
         "## quick hack (not recommended) - you can hardcode the config key here\n",
         "# NEBIUS_API_KEY = \"your_key_here\"\n",
         "\n",
+        "NEBIUS_BASE_URL = \"https://api.tokenfactory.nebius.com/v1/\"\n",
+        "NEBIUS_MODEL = os.getenv(\"NEBIUS_MODEL\", \"openai/gpt-oss-120b\").strip()\n",
+        "\n",
         "if NEBIUS_API_KEY:\n",
         "  print ('✅ NEBIUS_API_KEY found')\n",
         "  os.environ['NEBIUS_API_KEY'] = NEBIUS_API_KEY\n",
@@ -114,7 +108,7 @@
         "## 3 - Pick a Model\n",
         "\n",
         "1. Go to **models** tab in [tokenfactory.nebius.com](https://tokenfactory.nebius.com/)\n",
-        "2. Copy the model name.  For example **`openai/gpt-oss-120b-Instruct-2507`**\n",
+        "2. Copy the exact model ID. This notebook defaults to **`openai/gpt-oss-120b`**, which was present in the public catalog on 2026-08-13. Set `NEBIUS_MODEL` to override it if the catalog changes.\n",
         "\n",
         "![](https://raw.githubusercontent.com/nebius/token-factory-cookbook/main/images/token-factory-1-models.png)"
       ]
@@ -128,7 +122,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -136,55 +130,7 @@
         "id": "R8htBO7iH6-e",
         "outputId": "f5280299-a087-4708-c1dc-4c2f5669bf08"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "----model answer -----\n",
-            "The capital of the Netherlands is Amsterdam.\n",
-            "\n",
-            "----- full response ----\n",
-            "{\n",
-            "  \"id\": \"chatcmpl-63c63b527d454383946b3481709c2b81\",\n",
-            "  \"created\": 1762232294,\n",
-            "  \"model\": \"nebius/openai/gpt-oss-120b-Instruct-2507\",\n",
-            "  \"object\": \"chat.completion\",\n",
-            "  \"system_fingerprint\": null,\n",
-            "  \"choices\": [\n",
-            "    {\n",
-            "      \"finish_reason\": \"stop\",\n",
-            "      \"index\": 0,\n",
-            "      \"message\": {\n",
-            "        \"content\": \"The capital of the Netherlands is Amsterdam.\",\n",
-            "        \"role\": \"assistant\",\n",
-            "        \"tool_calls\": null,\n",
-            "        \"function_call\": null\n",
-            "      },\n",
-            "      \"provider_specific_fields\": {\n",
-            "        \"stop_reason\": null,\n",
-            "        \"token_ids\": null\n",
-            "      }\n",
-            "    }\n",
-            "  ],\n",
-            "  \"usage\": {\n",
-            "    \"completion_tokens\": 9,\n",
-            "    \"prompt_tokens\": 15,\n",
-            "    \"total_tokens\": 24,\n",
-            "    \"completion_tokens_details\": null,\n",
-            "    \"prompt_tokens_details\": null\n",
-            "  },\n",
-            "  \"service_tier\": null,\n",
-            "  \"prompt_logprobs\": null,\n",
-            "  \"prompt_token_ids\": null,\n",
-            "  \"kv_transfer_params\": null\n",
-            "}\n",
-            "---------\n",
-            "CPU times: user 820 ms, sys: 194 ms, total: 1.01 s\n",
-            "Wall time: 4.25 s\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%%time\n",
         "\n",
@@ -192,7 +138,9 @@
         "from litellm import completion\n",
         "\n",
         "response = completion(\n",
-        "    model=\"nebius/openai/gpt-oss-120b-Instruct-2507\",\n",
+        "    model=f\"nebius/{NEBIUS_MODEL}\",\n",
+        "    api_key=NEBIUS_API_KEY,\n",
+        "    api_base=NEBIUS_BASE_URL,\n",
         "    messages=[\n",
         "        {\n",
         "            \"role\": \"user\",\n",

--- a/api/api_llamaindex.ipynb
+++ b/api/api_llamaindex.ipynb
@@ -16,7 +16,7 @@
         "- [llama-index](https://docs.llamaindex.ai/en/stable/)\n",
         "- [LlamaIndex + nebius API examples](https://docs.llamaindex.ai/en/stable/api_reference/llms/nebius/#llama_index.llms.nebius.NebiusLLM)\n",
         "\n",
-        "## Pre requisites\n",
+        "## Prerequisites\n",
         "\n",
         "- Nebius API key.  Sign up for free at [Token Factory](https://tokenfactory.nebius.com/)\n",
         "- And complete [the setup](https://github.com/nebius/token-factory-cookbook/blob/main/getting-started.md)\n",
@@ -46,7 +46,7 @@
       "source": [
         "%%capture\n",
         "\n",
-        "!pip install -q  llama-index-llms-nebius  python-dotenv"
+        "!pip install -q \"llama-index-llms-nebius==0.3.0\" \"python-dotenv>=1,<2\""
       ]
     },
     {
@@ -60,7 +60,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 2,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -68,16 +68,7 @@
         "id": "sFSX16IeFLKa",
         "outputId": "40304ba1-036f-4e79-b836-2b706a9a1bcc"
       },
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "NOT running in Colab\n",
-            "✅ NEBIUS_API_KEY found\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "import os, sys\n",
         "\n",
@@ -98,6 +89,9 @@
         "## quick hack (not recommended) - you can hardcode the config key here\n",
         "# NEBIUS_API_KEY = \"your_key_here\"\n",
         "\n",
+        "NEBIUS_BASE_URL = \"https://api.tokenfactory.nebius.com/v1/\"\n",
+        "NEBIUS_MODEL = os.getenv(\"NEBIUS_MODEL\", \"openai/gpt-oss-120b\").strip()\n",
+        "\n",
         "if NEBIUS_API_KEY:\n",
         "  print ('✅ NEBIUS_API_KEY found')\n",
         "  os.environ['NEBIUS_API_KEY'] = NEBIUS_API_KEY\n",
@@ -114,7 +108,7 @@
         "## 3 - Pick a Model\n",
         "\n",
         "1. Go to **models** tab in [tokenfactory.nebius.com](https://tokenfactory.nebius.com/)\n",
-        "2. Copy the model name.  For example **`openai/gpt-oss-120b-Instruct-2507`**\n",
+        "2. Copy the exact model ID. This notebook defaults to **`openai/gpt-oss-120b`**, which was present in the public catalog on 2026-08-13. Set `NEBIUS_MODEL` to override it if the catalog changes.\n",
         "\n",
         "![](https://raw.githubusercontent.com/nebius/token-factory-cookbook/main/images/token-factory-1-models.png)"
       ]
@@ -128,7 +122,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 3,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -136,36 +130,16 @@
         "id": "R8htBO7iH6-e",
         "outputId": "f5280299-a087-4708-c1dc-4c2f5669bf08"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/Users/sujee/my-stuff/nebius/ai-studio-cookbook/upstream-2-tf-launch/.venv/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-            "  from .autonotebook import tqdm as notebook_tqdm\n",
-            "None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.\n"
-          ]
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "----model answer -----\n",
-            "The capital of the Netherlands is Amsterdam.\n",
-            "---------\n",
-            "CPU times: user 2.42 s, sys: 677 ms, total: 3.1 s\n",
-            "Wall time: 11.7 s\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "%%time\n",
         "\n",
         "from llama_index.llms.nebius import NebiusLLM\n",
         "\n",
         "llm = NebiusLLM(\n",
-        "    model=\"openai/gpt-oss-120b-Instruct-2507\", \n",
+        "    model=NEBIUS_MODEL,\n",
         "    api_key=NEBIUS_API_KEY,\n",
+        "    api_base=NEBIUS_BASE_URL,\n",
         "    temperature=0.1,  # either set temperature or `top_p`\n",
         ")\n",
         "\n",

--- a/api/requirements-aisuite.txt
+++ b/api/requirements-aisuite.txt
@@ -1,0 +1,4 @@
+aisuite==0.1.14
+docstring-parser==0.15
+openai>=2.20,<3
+python-dotenv>=1,<2

--- a/api/requirements-litellm.txt
+++ b/api/requirements-litellm.txt
@@ -1,0 +1,2 @@
+litellm==1.96.2
+python-dotenv>=1,<2

--- a/api/requirements-llamaindex.txt
+++ b/api/requirements-llamaindex.txt
@@ -1,0 +1,2 @@
+llama-index-llms-nebius==0.3.0
+python-dotenv>=1,<2

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,14 +1,11 @@
-openai
+# Shared notebook utilities. Framework adapters live in separate requirement
+# files because current aisuite and LiteLLM releases require incompatible
+# httpx versions and cannot be installed into one environment.
+openai>=2.20,<3
+python-dotenv>=1,<2
+ipykernel>=7,<8
 
-aisuite
-docstring-parser
-
-litellm
-
-llama-index-llms-nebius
-
-## python utils
-python-dotenv
-
-## jupyter notebook
-ipykernel
+# Choose one framework environment:
+#   pip install -r api/requirements-aisuite.txt
+#   pip install -r api/requirements-litellm.txt
+#   pip install -r api/requirements-llamaindex.txt

--- a/api/test_api_notebooks.py
+++ b/api/test_api_notebooks.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+API_DIR = Path(__file__).parent
+NOTEBOOKS = {
+    "aisuite": API_DIR / "api_aisuite.ipynb",
+    "litellm": API_DIR / "api_litellm.ipynb",
+    "llamaindex": API_DIR / "api_llamaindex.ipynb",
+}
+BASE_URL = "https://api.tokenfactory.nebius.com/v1/"
+REMOVED_MODEL = "openai/gpt-oss-120b-Instruct-2507"
+
+
+def notebook_text(path: Path) -> str:
+    notebook = json.loads(path.read_text())
+    return "\n".join(
+        "".join(cell.get("source", [])) for cell in notebook["cells"]
+    )
+
+
+class APIFrameworkNotebookTests(unittest.TestCase):
+    def test_notebooks_are_clean_and_portable(self):
+        for name, path in NOTEBOOKS.items():
+            with self.subTest(name=name):
+                notebook = json.loads(path.read_text())
+                self.assertEqual(notebook["nbformat"], 4)
+                for cell in notebook["cells"]:
+                    if cell["cell_type"] == "code":
+                        self.assertIsNone(cell["execution_count"])
+                        self.assertEqual(cell["outputs"], [])
+                serialized = json.dumps(notebook)
+                self.assertNotIn("/Users/", serialized)
+                self.assertNotIn(REMOVED_MODEL, serialized)
+
+    def test_python_cells_compile_after_notebook_magics_are_removed(self):
+        for name, path in NOTEBOOKS.items():
+            notebook = json.loads(path.read_text())
+            for index, cell in enumerate(notebook["cells"]):
+                if cell["cell_type"] != "code":
+                    continue
+                source = "".join(cell["source"])
+                python_source = "\n".join(
+                    line
+                    for line in source.splitlines()
+                    if not line.lstrip().startswith(("%", "!"))
+                )
+                with self.subTest(name=name, cell=index):
+                    compile(python_source, f"{path.name}:cell-{index}", "exec")
+
+    def test_each_notebook_uses_current_token_factory_contract(self):
+        for name, path in NOTEBOOKS.items():
+            with self.subTest(name=name):
+                text = notebook_text(path)
+                self.assertIn(BASE_URL, text)
+                self.assertIn("NEBIUS_API_KEY", text)
+                self.assertIn("NEBIUS_MODEL", text)
+
+    def test_framework_specific_routing_is_explicit(self):
+        aisuite = notebook_text(NOTEBOOKS["aisuite"])
+        self.assertIn('"openai": {', aisuite)
+        self.assertIn('provider = "openai"', aisuite)
+
+        litellm = notebook_text(NOTEBOOKS["litellm"])
+        self.assertIn('model=f"nebius/{NEBIUS_MODEL}"', litellm)
+        self.assertIn("api_base=NEBIUS_BASE_URL", litellm)
+
+        llamaindex = notebook_text(NOTEBOOKS["llamaindex"])
+        self.assertIn("NebiusLLM(", llamaindex)
+        self.assertIn("api_base=NEBIUS_BASE_URL", llamaindex)
+
+    def test_framework_dependencies_are_separate(self):
+        root = (API_DIR / "requirements.txt").read_text()
+        self.assertNotIn("aisuite==", root)
+        self.assertNotIn("litellm==", root)
+        self.assertNotIn("llama-index-llms-nebius==", root)
+        for name in NOTEBOOKS:
+            requirements = API_DIR / f"requirements-{name}.txt"
+            self.assertTrue(requirements.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- replace the nonexistent `openai/gpt-oss-120b-Instruct-2507` ID in the aisuite, LiteLLM, and LlamaIndex notebooks with the current `openai/gpt-oss-120b` catalog ID plus a `NEBIUS_MODEL` override
- route every example explicitly through `https://api.tokenfactory.nebius.com/v1/`
- use aisuite's existing generic OpenAI-compatible provider because aisuite 0.1.14's built-in Nebius provider still targets the former Studio host
- pass the canonical base URL explicitly to LiteLLM and LlamaIndex so the notebooks are correct independently of unreleased upstream fixes
- split framework requirements because aisuite 0.1.14 requires `httpx<0.28` while LiteLLM 1.96.2 requires `httpx>=0.28`
- clear saved outputs, execution counts, and the contributor-specific local path
- add five offline notebook contract tests

## Why

These are repairs to the three existing framework examples, not new provider integrations. The previous single environment is no longer resolvable, and the saved examples all selected a model ID that is absent from the current public catalog.

This PR is file-disjoint from #35: that draft owns the API index, Responses example, legacy-host/deprecation gate, and related CI; this one owns only the three framework notebooks, their dependency isolation, and notebook-specific tests.

## Validation

- `python3 -m unittest api/test_api_notebooks.py -v` (5 tests)
- installed each split requirements file successfully in an isolated Python 3.11 environment
- aisuite 0.1.14 mocked request reached `https://api.tokenfactory.nebius.com/v1/chat/completions`
- LiteLLM 1.96.2 completed its `mock_response` path with the explicit Token Factory base URL
- LlamaIndex Nebius 0.3.0 instantiated with `api_base=https://api.tokenfactory.nebius.com/v1/` and `model=openai/gpt-oss-120b`
- all three notebooks pass `python3 -m json.tool`
- `git diff --check`

No paid live inference call was made. The default model was checked against the public `models_info` catalog on 2026-08-13; users can override it with `NEBIUS_MODEL` if availability changes.