### PR TITLE
Clean batch notebook paths and execution artifacts

### DIFF
--- a/batch.ipynb
+++ b/batch.ipynb
@@ -1,218 +1,112 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Batch inference with Token Factory\n",
+    "\n",
+    "This notebook uploads a JSONL request file, creates a batch, checks that same batch, and downloads its output. Set `NEBIUS_BATCH_INPUT_PATH` to your JSONL file. Output is written to `NEBIUS_BATCH_OUTPUT_PATH` or a portable temporary-directory default.\n",
+    "\n",
+    "> Batch access may require project enablement and a configured batch endpoint. Confirm the current [Token Factory batch documentation](https://docs.tokenfactory.nebius.com/ai-models-inference/batch-inference) before running this notebook."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import json\n",
     "import os\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
     "from openai import OpenAI\n",
     "\n",
     "client = OpenAI(\n",
     "    base_url=\"https://api.tokenfactory.nebius.com/v1\",\n",
-    "    api_key=os.getenv('NEBIUS_API_KEY', ''),\n",
-    ")\n"
+    "    api_key=os.environ[\"NEBIUS_API_KEY\"],\n",
+    ")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 737,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'd8af680e-9be8-4634-b4a5-cfd675067aef',\n",
-       " 'bytes': 9120315571,\n",
-       " 'created_at': 1729516591,\n",
-       " 'filename': 'batch.jsonl',\n",
-       " 'object': 'file',\n",
-       " 'purpose': 'batch',\n",
-       " 'status': None,\n",
-       " 'status_details': None}"
-      ]
-     },
-     "execution_count": 737,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "batch_input_file = client.files.create(\n",
-    "  file=open(\"/Users/sofrony/batch.jsonl\", \"rb\"),\n",
-    "  purpose=\"batch\"\n",
-    ")\n",
+    "batch_input_path = Path(\n",
+    "    os.environ.get(\"NEBIUS_BATCH_INPUT_PATH\", \"batch.jsonl\")\n",
+    ").expanduser()\n",
+    "if not batch_input_path.is_file():\n",
+    "    raise FileNotFoundError(\n",
+    "        f\"Batch input not found at {batch_input_path}. \"\n",
+    "        \"Set NEBIUS_BATCH_INPUT_PATH to a JSONL request file.\"\n",
+    "    )\n",
     "\n",
-    "batch_input_file.dict()\n"
+    "with batch_input_path.open(\"rb\") as batch_input:\n",
+    "    uploaded_file = client.files.create(file=batch_input, purpose=\"batch\")\n",
+    "\n",
+    "print({\"input_file_id\": uploaded_file.id, \"filename\": batch_input_path.name})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 738,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "d8af680e-9be8-4634-b4a5-cfd675067aef\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'batch_3416ef9e-7176-4ba1-8b00-8080984e0970',\n",
-       " 'completion_window': '24h',\n",
-       " 'created_at': 1729516667,\n",
-       " 'endpoint': '/v1/chat/completions',\n",
-       " 'input_file_id': 'd8af680e-9be8-4634-b4a5-cfd675067aef',\n",
-       " 'object': 'batch',\n",
-       " 'status': 'validating',\n",
-       " 'request_counts': {}}"
-      ]
-     },
-     "execution_count": 738,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "batch_input_file_id = batch_input_file.id\n",
-    "print(batch_input_file_id)\n",
-    "\n",
-    "batch_id = client.batches.create(\n",
-    "    input_file_id=batch_input_file_id,\n",
+    "batch = client.batches.create(\n",
+    "    input_file_id=uploaded_file.id,\n",
     "    endpoint=\"/v1/chat/completions\",\n",
     "    completion_window=\"24h\",\n",
-    "    metadata={\n",
-    "      \"description\": \"nightly eval job\"\n",
-    "    }\n",
+    "    metadata={\"description\": \"nightly eval job\"},\n",
     ")\n",
     "\n",
-    "batch_id.to_dict()"
+    "print({\"batch_id\": batch.id, \"status\": batch.status})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 739,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'batch_3416ef9e-7176-4ba1-8b00-8080984e0970',\n",
-       " 'completion_window': '24h',\n",
-       " 'created_at': 1729516667,\n",
-       " 'endpoint': '/v1/chat/completions',\n",
-       " 'input_file_id': 'd8af680e-9be8-4634-b4a5-cfd675067aef',\n",
-       " 'object': 'batch',\n",
-       " 'status': 'validating',\n",
-       " 'completed_at': None,\n",
-       " 'error_file_id': None,\n",
-       " 'finalizing_at': None,\n",
-       " 'in_progress_at': None,\n",
-       " 'output_file_id': None,\n",
-       " 'request_counts': {}}"
-      ]
-     },
-     "execution_count": 739,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# Re-run this cell until the batch reaches a terminal state.\n",
+    "status = client.batches.retrieve(batch.id)\n",
+    "print(\n",
+    "    {\n",
+    "        \"batch_id\": status.id,\n",
+    "        \"status\": status.status,\n",
+    "        \"request_counts\": status.request_counts,\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if not status.output_file_id:\n",
+    "    raise RuntimeError(\n",
+    "        f\"Batch {status.id} has no output file yet (status: {status.status}).\"\n",
+    "    )\n",
     "\n",
-    "status = client.batches.retrieve(batch_id.id)\n",
-    "status.to_dict()\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 753,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'batch_df3346b5-4c2c-4f36-9b30-aeedfa485a59',\n",
-       " 'completion_window': '24h',\n",
-       " 'created_at': 1729502538,\n",
-       " 'endpoint': '/v1/chat/completions',\n",
-       " 'input_file_id': '6425e0cf-1f38-48c0-882b-c34336112cc0',\n",
-       " 'object': 'batch',\n",
-       " 'status': 'done',\n",
-       " 'completed_at': 1729513364,\n",
-       " 'error_file_id': None,\n",
-       " 'finalizing_at': 1729513363,\n",
-       " 'in_progress_at': 1729502547,\n",
-       " 'output_file_id': 'f01cbeef-4714-4edb-8896-25b712d287db',\n",
-       " 'request_counts': {'completed': 4, 'failed': 0, 'total': 4}}"
-      ]
-     },
-     "execution_count": 753,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "batch_id = client.batches.list().dict()['data'][0]['id']\n",
-    "status = client.batches.retrieve(batch_id)\n",
-    "status.to_dict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 754,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'id': 'f01cbeef-4714-4edb-8896-25b712d287db',\n",
-       " 'bytes': 2477,\n",
-       " 'created_at': 1729513364,\n",
-       " 'filename': 'batch_df3346b5-4c2c-4f36-9b30-aeedfa485a59_output.jsonl',\n",
-       " 'object': 'file',\n",
-       " 'purpose': 'batch',\n",
-       " 'status': None,\n",
-       " 'status_details': None}"
-      ]
-     },
-     "execution_count": 754,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "file_response = client.files.retrieve(status.output_file_id)\n",
-    "file_response.dict()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 755,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'id': 'batch_req_e3f24ba0-8305-4395-9d1f-95703a363986', 'custom_id': 'request-1', 'response': {'id': 'chat-1bd17149372044158cc19d7859a5506d', 'choices': [{'finish_reason': 'stop', 'index': 0, 'logprobs': None, 'message': {'content': 'Hello! How can I assist you today?', 'role': 'assistant', 'function_call': None, 'tool_calls': []}, 'stop_reason': None}], 'created': 1729513357, 'model': 'meta-llama/Meta-Llama-3.1-8B-Instruct-fast', 'object': 'chat.completion', 'service_tier': None, 'system_fingerprint': None, 'usage': {'completion_tokens': 10, 'prompt_tokens': 22, 'total_tokens': 32}, 'prompt_logprobs': None}, 'error': None}\n",
-      "{'id': 'batch_req_ded9f16e-af25-466b-a155-27a3a72dc09e', 'custom_id': 'request-2', 'response': {'id': 'chat-41d9be70810441c68b2fcd89b7f3bc58', 'choices': [{'finish_reason': 'stop', 'index': 0, 'logprobs': None, 'message': {'content': '*shrugs*', 'role': 'assistant', 'function_call': None, 'tool_calls': []}, 'stop_reason': None}], 'created': 1729513359, 'model': 'meta-llama/Meta-Llama-3.1-8B-Instruct-fast', 'object': 'chat.completion', 'service_tier': None, 'system_fingerprint': None, 'usage': {'completion_tokens': 5, 'prompt_tokens': 24, 'total_tokens': 29}, 'prompt_logprobs': None}, 'error': None}\n",
-      "{'id': 'batch_req_f1dbb223-86b6-4f1f-9697-4c07cdd1df86', 'custom_id': 'request-2', 'response': {'id': 'chat-a42fe71b08214b0e95234ddde13f995d', 'choices': [{'finish_reason': 'stop', 'index': 0, 'logprobs': None, 'message': {'content': '*sits silently*', 'role': 'assistant', 'function_call': None, 'tool_calls': []}, 'stop_reason': None}], 'created': 1729513360, 'model': 'meta-llama/Meta-Llama-3.1-8B-Instruct-fast', 'object': 'chat.completion', 'service_tier': None, 'system_fingerprint': None, 'usage': {'completion_tokens': 5, 'prompt_tokens': 24, 'total_tokens': 29}, 'prompt_logprobs': None}, 'error': None}\n",
-      "{'id': 'batch_req_374315b6-4749-4239-8f47-de39293bc48d', 'custom_id': 'request-1', 'response': {'id': 'chat-b8cca8b11f434e07b1698bc3948b1a3b', 'choices': [{'finish_reason': 'stop', 'index': 0, 'logprobs': None, 'message': {'content': 'How can I assist you today?', 'role': 'assistant', 'function_call': None, 'tool_calls': []}, 'stop_reason': None}], 'created': 1729513360, 'model': 'meta-llama/Meta-Llama-3.1-8B-Instruct-fast', 'object': 'chat.completion', 'service_tier': None, 'system_fingerprint': None, 'usage': {'completion_tokens': 8, 'prompt_tokens': 22, 'total_tokens': 30}, 'prompt_logprobs': None}, 'error': None}\n"
-     ]
-    }
-   ],
-   "source": [
-    "import json\n",
     "file_response = client.files.content(status.output_file_id)\n",
-    "lines = file_response.content.splitlines()\n",
-    "for line in lines:\n",
-    "    print(json.loads(line))"
+    "default_output_path = Path(tempfile.gettempdir()) / \"nebius-batch-output.jsonl\"\n",
+    "batch_output_path = Path(\n",
+    "    os.environ.get(\"NEBIUS_BATCH_OUTPUT_PATH\", str(default_output_path))\n",
+    ").expanduser()\n",
+    "batch_output_path.parent.mkdir(parents=True, exist_ok=True)\n",
+    "batch_output_path.write_bytes(file_response.content)\n",
+    "\n",
+    "with batch_output_path.open(encoding=\"utf-8\") as output_file:\n",
+    "    result_count = sum(1 for line in output_file if line.strip() and json.loads(line))\n",
+    "\n",
+    "print(f\"Saved {result_count} batch result(s) to {batch_output_path}\")"
    ]
   }
  ],

--- a/test_batch_notebook.py
+++ b/test_batch_notebook.py
@@ -1,0 +1,128 @@
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+
+NOTEBOOK_PATH = Path(__file__).with_name("batch.ipynb")
+
+
+class BatchNotebookHygieneTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.notebook = json.loads(NOTEBOOK_PATH.read_text(encoding="utf-8"))
+        cls.source = "\n".join(
+            "".join(cell.get("source", [])) for cell in cls.notebook["cells"]
+        )
+
+    def test_notebook_has_no_committed_execution_state(self):
+        for cell in self.notebook["cells"]:
+            if cell["cell_type"] == "code":
+                self.assertIsNone(cell["execution_count"])
+                self.assertEqual(cell["outputs"], [])
+
+    def test_code_cells_compile(self):
+        for index, cell in enumerate(self.notebook["cells"]):
+            if cell["cell_type"] == "code":
+                compile("".join(cell["source"]), f"batch.ipynb:cell-{index}", "exec")
+
+    def test_notebook_has_no_machine_specific_paths_or_stored_resource_ids(self):
+        serialized = json.dumps(self.notebook)
+        self.assertNotRegex(serialized, r"/(?:Users|home)/[^/\"\\]+/")
+        self.assertNotRegex(serialized, r"batch_[0-9a-f]{8}-[0-9a-f-]{27,}")
+        self.assertNotRegex(serialized, r"(?:file-|chat-)[0-9a-f]{12,}")
+
+    def test_notebook_uses_configurable_portable_paths(self):
+        self.assertIn("NEBIUS_BATCH_INPUT_PATH", self.source)
+        self.assertIn("NEBIUS_BATCH_OUTPUT_PATH", self.source)
+        self.assertIn("tempfile.gettempdir()", self.source)
+        self.assertIn("Path(", self.source)
+
+    def test_notebook_retrieves_the_batch_it_created(self):
+        self.assertIn("client.batches.retrieve(batch.id)", self.source)
+        self.assertNotIn("client.batches.list()", self.source)
+
+    def test_notebook_uses_canonical_endpoint_and_environment_key(self):
+        self.assertIn("https://api.tokenfactory.nebius.com/v1", self.source)
+        self.assertIn('os.environ["NEBIUS_API_KEY"]', self.source)
+
+    def test_notebook_flow_runs_offline_with_a_fake_client(self):
+        calls = []
+
+        class FakeFiles:
+            def create(self, *, file, purpose):
+                calls.append(("files.create", file.read(), purpose))
+                return types.SimpleNamespace(id="file-example")
+
+            def content(self, file_id):
+                calls.append(("files.content", file_id))
+                return types.SimpleNamespace(
+                    content=b'{"custom_id":"request-1","response":{}}\n'
+                )
+
+        class FakeBatches:
+            def create(self, **kwargs):
+                calls.append(("batches.create", kwargs))
+                return types.SimpleNamespace(id="batch-example", status="validating")
+
+            def retrieve(self, batch_id):
+                calls.append(("batches.retrieve", batch_id))
+                return types.SimpleNamespace(
+                    id=batch_id,
+                    status="completed",
+                    request_counts={"completed": 1, "failed": 0, "total": 1},
+                    output_file_id="file-output-example",
+                )
+
+        class FakeOpenAI:
+            def __init__(self, *, base_url, api_key):
+                calls.append(("OpenAI", base_url, api_key))
+                self.files = FakeFiles()
+                self.batches = FakeBatches()
+
+        fake_openai = types.ModuleType("openai")
+        fake_openai.OpenAI = FakeOpenAI
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            input_path = Path(temp_dir) / "requests.jsonl"
+            output_path = Path(temp_dir) / "results.jsonl"
+            input_path.write_text('{"custom_id":"request-1"}\n', encoding="utf-8")
+            environment = {
+                "NEBIUS_API_KEY": "test-key",
+                "NEBIUS_BATCH_INPUT_PATH": str(input_path),
+                "NEBIUS_BATCH_OUTPUT_PATH": str(output_path),
+            }
+            namespace = {}
+            with (
+                patch.dict(os.environ, environment, clear=False),
+                patch.dict(sys.modules, {"openai": fake_openai}),
+                redirect_stdout(StringIO()),
+            ):
+                for index, cell in enumerate(self.notebook["cells"]):
+                    if cell["cell_type"] == "code":
+                        exec(
+                            compile(
+                                "".join(cell["source"]),
+                                f"batch.ipynb:cell-{index}",
+                                "exec",
+                            ),
+                            namespace,
+                        )
+
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"),
+                '{"custom_id":"request-1","response":{}}\n',
+            )
+
+        self.assertIn(("batches.retrieve", "batch-example"), calls)
+        self.assertNotIn("batches.list", [call[0] for call in calls])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the machine-specific input path with NEBIUS_BATCH_INPUT_PATH and a portable relative default
- write downloaded results to NEBIUS_BATCH_OUTPUT_PATH or the system temporary directory
- clear committed execution counts, resource IDs, and generated outputs
- retrieve the batch created by the notebook instead of selecting the newest account-wide batch
- add an offline regression test that compiles and executes the notebook flow with a fake client

## Verification

- python3 -m unittest -v test_batch_notebook.py (7 tests)
- python3 -m json.tool batch.ipynb
- jq structural check for cleared code-cell outputs and execution counts
- git diff --check

## Scope

This is a hygiene and safety repair only. It does not claim broad Batch availability and does not perform a live API call because no credential was used.