### PR TITLE
Enrich OpenClaw setup with safe config and lifecycle checks

### DIFF
--- a/integrations/openclaw/.env.example
+++ b/integrations/openclaw/.env.example
@@ -1,0 +1,2 @@
+# Export this variable in the environment that starts OpenClaw.
+NEBIUS_API_KEY=

--- a/integrations/openclaw/README.md
+++ b/integrations/openclaw/README.md
@@ -1,83 +1,151 @@
 # OpenClaw + Nebius Token Factory
 
-[OpenClaw](https://openclaw.ai/) is a self-hosted AI assistant that connects chat apps (WhatsApp, Telegram, Discord, and more) to LLM providers. Because [Nebius Token Factory](https://tokenfactory.nebius.com/) serves open models through an **OpenAI-compatible API**, you can point OpenClaw at Token Factory and run your agents on models like Qwen3, Llama, and DeepSeek.
+[OpenClaw](https://openclaw.ai/) can use custom OpenAI-compatible model
+providers. This recipe registers
+[Nebius Token Factory](https://tokenfactory.nebius.com/) as a custom provider,
+keeps the API key outside the configuration file, and shows how to verify the
+selected model before starting the gateway.
 
-## Why Token Factory?
-
-- **OpenAI-compatible** — no special SDK, OpenClaw's built-in OpenAI provider works as-is.
-- **Open models** — Qwen3, Kimi, DeepSeek, GLM and more, all behind one API key.
-- **Cost control** — usage-based pricing with no infra to manage.
+> **Last verified:** 2026-08-13 against the Token Factory public model catalog
+> and OpenClaw `2026.7.1-2`. The validation in this repository is offline; it
+> does not make a paid inference request.
 
 ## Prerequisites
 
-- A running [OpenClaw](https://docs.openclaw.ai/) instance.
-- A Nebius Token Factory API key — see [Getting Started](../../getting-started.md) for how to create one.
+- A working [OpenClaw installation](https://docs.openclaw.ai/start/getting-started)
+- A Token Factory account and API key; see [Getting Started](../../getting-started.md)
+- A model available to your Token Factory account
 
-## 1. Get your API key
+## 1. Keep the API key out of configuration
 
-Grab a key from [tokenfactory.nebius.com](https://tokenfactory.nebius.com/)
-
-## 2. Add Token Factory as a provider
-
-```bash
-openclaw --configure
-```
-
-- Choose '**Configure Models**'
-- choose '**Custom provider**'
-- base url = `https://api.tokenfactory.nebius.com/v1`
-- API KEY = `paste your nebius API key`
-- Select **OpenAI comptible**
-- model id =  `moonshotai/Kimi-K2.6`  (or any model id from Token Factory)
-- End point id = **nebius-token-factory**
-- model alias : leave blank
-  
-
-### Model Selection
-
-Model IDs use the `org/model` form. A few options:
-
-| Model | ID |
-|-------|----|
-| Kimi-K2.6 | `moonshotai/Kimi-K2.6` |
-| DeepSeek-V4-Pro | `deepseek-ai/DeepSeek-V4-Pro` |
-| GLM-5.1 | `zai-org/GLM-5.1` |
-
-See the full catalog at [tokenfactory.nebius.com](https://tokenfactory.nebius.com/) or the [Models guides](../../models/) in this cookbook.
-
-That's it!
-
-## 3. Restart OpenClaw
-
-Be sure to restart the openclaw gateway for changes to take effect.
+Export the key in the environment that starts the OpenClaw gateway:
 
 ```bash
-openclaw  gateway run
-# or 
-openclaw  gateway restart
+export NEBIUS_API_KEY="your-token-factory-api-key"
 ```
 
-Then launch openclaw as 
+For a persistent installation, set `NEBIUS_API_KEY` with your service manager
+or secret store. Do not paste the key into `openclaw.json`, commit it, or put it
+in shell history. The included [`.env.example`](.env.example) is a
+variable-name reference, not a file to fill in and commit.
+
+## 2. Register Token Factory
+
+Merge the contents of
+[`openclaw.example.json`](openclaw.example.json) into
+`~/.openclaw/openclaw.json`. If you already have provider or agent settings,
+preserve them; do not replace the whole file blindly.
+
+The important provider fields are:
+
+```json
+{
+  "baseUrl": "https://api.tokenfactory.nebius.com/v1",
+  "apiKey": "${NEBIUS_API_KEY}",
+  "api": "openai-completions"
+}
+```
+
+- Keep `/v1` in `baseUrl`.
+- Use `openai-completions` for Token Factory's OpenAI-compatible Chat
+  Completions path.
+- Model references have the form `nebius-token-factory/<org>/<model>`.
+  OpenClaw removes the provider prefix and sends the remaining `<org>/<model>`
+  ID to Token Factory.
+
+The example selects:
+
+```text
+nebius-token-factory/moonshotai/Kimi-K2.6
+```
+
+## 3. Verify configuration before starting the gateway
+
+Run OpenClaw's configuration and model diagnostics:
 
 ```bash
-# web based UI
-openclaw  dashboard
-
-# Terminal based ui
-openclaw  tui
+openclaw config validate
+openclaw models status
+openclaw models list --provider nebius-token-factory
 ```
 
+These commands verify the local schema and model registration. OpenClaw's
+model-list command is read-only and does not call the provider, so it does not
+prove account access or live inference readiness. Token Factory's
+[public model catalog](https://tokenfactory.nebius.com/api/public/models_info)
+is the lifecycle source to check before choosing a different model.
 
+Then restart the gateway and open a client:
 
+```bash
+openclaw gateway restart
+openclaw dashboard
+# or: openclaw tui
+```
+
+For a first request, use a low token limit and inspect the response before
+enabling the model in unattended agents.
+
+## Model lifecycle note
+
+These example IDs were present with `active` status in the public catalog when
+this recipe was last verified:
+
+| Model | Token Factory model ID |
+| --- | --- |
+| Kimi K2.6 | `moonshotai/Kimi-K2.6` |
+| DeepSeek V4 Flash | `deepseek-ai/DeepSeek-V4-Flash` |
+| GLM 5.1 | `zai-org/GLM-5.1` |
+
+Kimi K2.6 and GLM 5.1 both had public `active` status on 2026-08-13. This recipe
+retains both IDs and does not infer a deprecation or replacement from an
+unconfirmed lifecycle signal. Re-check the public catalog and your account
+before deploying or changing a production default; use the exact case-sensitive
+ID returned there.
+
+## Updating the default model
+
+1. Confirm the model is in the current catalog and available to your account.
+2. Add its exact ID under `models.providers.nebius-token-factory.models`.
+3. Set `agents.defaults.model.primary` to `nebius-token-factory/<exact-model-id>`.
+4. Re-run `openclaw config validate` and `openclaw models status`.
+
+Do not infer a replacement from an unconfirmed lifecycle signal. Wait for the
+public lifecycle state or an official migration path.
 
 ## Troubleshooting
 
-- **401 Unauthorized** — check that `NEBIUS_API_KEY` is set and the provider config references it correctly.
-- **404 / model not found** — verify the model ID (`org/model`, case-sensitive) and that it's available on your account.
-- **Wrong endpoint** — the `base_url` must end in `/v1`; do not append `/chat/completions` yourself.
+- **Missing environment variable** — export `NEBIUS_API_KEY` in the same
+  environment that launches the gateway. A desktop shell and a system service
+  may not share environment variables.
+- **401 Unauthorized** — verify the key is active and that OpenClaw resolves
+  `${NEBIUS_API_KEY}` rather than storing a literal placeholder.
+- **404 / model not found** — copy the exact case-sensitive model ID from the
+  current catalog and confirm it is available to your account.
+- **Wrong route** — `baseUrl` must be exactly
+  `https://api.tokenfactory.nebius.com/v1`; do not append `/chat/completions`.
+- **Provider appears but model does not** — a custom model must be registered in
+  `models.providers.nebius-token-factory.models`; adding only an alias under
+  `agents.defaults.models` does not register it.
+- **Existing configuration disappears** — restore your backup and merge the
+  provider block instead of replacing `openclaw.json`.
+
+## Offline validation for contributors
+
+From the repository root:
+
+```bash
+python -m unittest integrations.openclaw.test_recipe
+```
+
+The test checks the JSON example, canonical endpoint, environment-backed secret
+reference, provider/model IDs, lifecycle note, and common secret/configuration
+regressions. It does not require an API key or network access.
 
 ## Resources
 
-- [OpenClaw docs](https://docs.openclaw.ai/)
-- [Token Factory docs](https://docs.tokenfactory.nebius.com/)
-- [Cookbook: Getting Started](../../getting-started.md)
+- [OpenClaw custom providers](https://docs.openclaw.ai/concepts/model-providers#providers-via-modelsproviders-custombase-url)
+- [OpenClaw models CLI](https://docs.openclaw.ai/concepts/models)
+- [Token Factory documentation](https://docs.tokenfactory.nebius.com/)
+- [Token Factory public model catalog](https://tokenfactory.nebius.com/api/public/models_info)
+- [Cookbook Getting Started](../../getting-started.md)

--- a/integrations/openclaw/openclaw.example.json
+++ b/integrations/openclaw/openclaw.example.json
@@ -1,0 +1,53 @@
+{
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "nebius-token-factory/moonshotai/Kimi-K2.6"
+      },
+      "models": {
+        "nebius-token-factory/moonshotai/Kimi-K2.6": {
+          "alias": "Kimi K2.6 on Token Factory"
+        },
+        "nebius-token-factory/deepseek-ai/DeepSeek-V4-Flash": {
+          "alias": "DeepSeek V4 Flash on Token Factory"
+        },
+        "nebius-token-factory/zai-org/GLM-5.1": {
+          "alias": "GLM 5.1 on Token Factory"
+        }
+      }
+    }
+  },
+  "models": {
+    "mode": "merge",
+    "providers": {
+      "nebius-token-factory": {
+        "baseUrl": "https://api.tokenfactory.nebius.com/v1",
+        "apiKey": "${NEBIUS_API_KEY}",
+        "api": "openai-completions",
+        "models": [
+          {
+            "id": "moonshotai/Kimi-K2.6",
+            "name": "Kimi K2.6",
+            "input": [
+              "text"
+            ]
+          },
+          {
+            "id": "deepseek-ai/DeepSeek-V4-Flash",
+            "name": "DeepSeek V4 Flash",
+            "input": [
+              "text"
+            ]
+          },
+          {
+            "id": "zai-org/GLM-5.1",
+            "name": "GLM 5.1",
+            "input": [
+              "text"
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/integrations/openclaw/test_recipe.py
+++ b/integrations/openclaw/test_recipe.py
@@ -1,0 +1,76 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+RECIPE_DIR = Path(__file__).parent
+PROVIDER_ID = "nebius-token-factory"
+EXPECTED_MODEL_IDS = {
+    "moonshotai/Kimi-K2.6",
+    "deepseek-ai/DeepSeek-V4-Flash",
+    "zai-org/GLM-5.1",
+}
+
+
+class OpenClawRecipeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.config_text = (RECIPE_DIR / "openclaw.example.json").read_text()
+        cls.config = json.loads(cls.config_text)
+        cls.readme = (RECIPE_DIR / "README.md").read_text()
+
+    def test_provider_uses_canonical_chat_completions_endpoint(self) -> None:
+        provider = self.config["models"]["providers"][PROVIDER_ID]
+
+        self.assertEqual(
+            provider["baseUrl"], "https://api.tokenfactory.nebius.com/v1"
+        )
+        self.assertEqual(provider["api"], "openai-completions")
+        self.assertEqual(provider["apiKey"], "${NEBIUS_API_KEY}")
+
+    def test_registered_models_and_agent_references_match(self) -> None:
+        provider = self.config["models"]["providers"][PROVIDER_ID]
+        registered_ids = {model["id"] for model in provider["models"]}
+        agent_models = set(self.config["agents"]["defaults"]["models"])
+        expected_agent_models = {
+            f"{PROVIDER_ID}/{model_id}" for model_id in EXPECTED_MODEL_IDS
+        }
+
+        self.assertEqual(registered_ids, EXPECTED_MODEL_IDS)
+        self.assertEqual(agent_models, expected_agent_models)
+        self.assertIn(
+            self.config["agents"]["defaults"]["model"]["primary"], agent_models
+        )
+
+    def test_active_models_are_retained_until_public_lifecycle_changes(self) -> None:
+        for model_id in ("moonshotai/Kimi-K2.6", "zai-org/GLM-5.1"):
+            self.assertIn(model_id, self.config_text)
+            self.assertIn(model_id, self.readme)
+
+        self.assertIn("both had public `active` status", self.readme)
+        self.assertIn("does not infer a deprecation or replacement", self.readme)
+        self.assertIn("Last verified:** 2026-08-13", self.readme)
+
+    def test_example_does_not_contain_a_literal_secret_or_legacy_host(self) -> None:
+        combined = "\n".join(
+            [
+                self.config_text,
+                self.readme,
+                (RECIPE_DIR / ".env.example").read_text(),
+            ]
+        )
+
+        self.assertNotIn("studio.nebius.ai", combined)
+        self.assertNotIn("api.studio.nebius.ai", combined)
+        self.assertNotRegex(combined, re.compile(r"(?:sk|nvapi)-[A-Za-z0-9_-]{16,}"))
+
+    def test_readme_contains_offline_verification_and_lifecycle_sources(self) -> None:
+        self.assertIn("openclaw config validate", self.readme)
+        self.assertIn("openclaw models status", self.readme)
+        self.assertIn("public/models_info", self.readme)
+        self.assertIn("does not make a paid inference request", self.readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enrich the existing OpenClaw integration instead of adding a duplicate recipe
- add a checked-in custom-provider configuration that uses the canonical Token Factory `/v1` base URL and `openai-completions`
- keep the API key environment-backed and add secret/configuration guardrails
- add an explicit 2026-08-13 lifecycle note: Kimi K2.6 and GLM 5.1 remain in the example because both had public `active` status; the recipe does not infer a deprecation or replacement from unconfirmed signals
- add offline regression tests for endpoint, provider/model references, retained IDs, lifecycle language, and secret leakage

## Validation

- `python3 -m unittest integrations.openclaw.test_recipe` — 5 passed
- `python3 -m json.tool integrations/openclaw/openclaw.example.json` — passed
- `npx --yes markdownlint-cli2 integrations/openclaw/README.md` — 0 issues
- `OPENCLAW_CONFIG_PATH="$PWD/integrations/openclaw/openclaw.example.json" NEBIUS_API_KEY='offline-schema-placeholder' npx --yes openclaw@2026.7.1-2 config validate` — valid
- same released CLI with `models list --provider nebius-token-factory --plain` — all 3 configured model refs resolved
- `git diff --check` — passed

No paid inference request was made. The three example IDs were checked against the public Token Factory catalog on 2026-08-13; account-specific availability still needs to be verified by the user.

## Scope / overlap

This changes only `integrations/openclaw/`. It does not overlap the open API repair, agent, editor, or other integration PRs.
