### PR TITLE
Harden and verify the Pixeltable recipe

### DIFF
--- a/integrations/pixeltable/README.md
+++ b/integrations/pixeltable/README.md
@@ -1,25 +1,37 @@
 # Pixeltable + Nebius Token Factory
 
-[Pixeltable](https://pixeltable.com/) is open-source multimodal AI data infrastructure. You declare tables with images, video, audio, documents, and text; computed columns and embedding indexes run incrementally as data arrives. Pixeltable includes a **native Nebius Token Factory provider** (`pixeltable.functions.nebius`) for chat completions and embeddings—no custom base-URL wiring required.
+[Pixeltable](https://pixeltable.com/) is open-source multimodal AI data
+infrastructure. You declare tables with images, video, audio, documents, and
+text; computed columns and embedding indexes run incrementally as data arrives.
+Pixeltable includes a **native Nebius Token Factory provider**
+(`pixeltable.functions.nebius`) for chat completions and embeddings—no custom
+base-URL wiring required.
 
 ## Why Token Factory?
 
-- **Native UDFs** — `nebius.chat_completions` and `nebius.embeddings` call Token Factory directly.
+- **Native UDFs** — `nebius.chat_completions` and `nebius.embeddings` call
+  Token Factory directly.
 - **Open models** — Llama, Qwen, DeepSeek, and more behind one API key.
-- **Incremental pipelines** — insert rows; Pixeltable fills computed columns and maintains indexes automatically.
+- **Incremental pipelines** — insert rows; Pixeltable fills computed columns
+  and maintains indexes automatically.
 
 ## Prerequisites
 
 - A Nebius Token Factory API key — see [Getting Started](../../getting-started.md).
 - Python 3.10+ (local, Colab, etc.).
 
+This recipe was contract-checked with Pixeltable 0.7.1 on 2026-08-13. It uses
+Pixeltable's existing native Nebius UDFs and Chat Completions; it does not add
+another provider or claim Responses API support.
+
 ## 1. Install
 
 ```bash
-pip install -U pixeltable openai
+pip install "pixeltable==0.7.1" openai
 ```
 
-Nebius uses an OpenAI-compatible API, so the `openai` package is required alongside Pixeltable.
+Nebius uses an OpenAI-compatible API, so the `openai` package is required
+alongside Pixeltable.
 
 ## 2. Set your API key
 
@@ -27,18 +39,21 @@ Nebius uses an OpenAI-compatible API, so the `openai` package is required alongs
 export NEBIUS_API_KEY=your_key_here
 ```
 
-Or in Python:
-
-```python
-import os
-os.environ['NEBIUS_API_KEY'] = 'your_key_here'
-```
+Keep the key outside notebooks and source control. For a local notebook, set the
+environment variable in the shell that launches Jupyter rather than saving a
+key assignment in a cell.
 
 ## 3. Chat completions
 
 ```python
+import os
+
 import pixeltable as pxt
 from pixeltable.functions import nebius
+
+CHAT_MODEL = os.getenv(
+    'NEBIUS_CHAT_MODEL', 'meta-llama/Llama-3.3-70B-Instruct'
+)
 
 pxt.drop_dir('nebius_demo', force=True)
 pxt.create_dir('nebius_demo')
@@ -49,7 +64,7 @@ messages = [{'role': 'user', 'content': chat_t.input}]
 chat_t.add_computed_column(
     output=nebius.chat_completions(
         messages=messages,
-        model='meta-llama/Llama-3.3-70B-Instruct',
+        model=CHAT_MODEL,
         model_kwargs={'max_tokens': 300, 'temperature': 0.7},
     )
 )
@@ -59,11 +74,17 @@ chat_t.insert([{'input': 'What is the capital of France?'}])
 chat_t.select(chat_t.input, chat_t.response).collect()
 ```
 
-Model IDs use the `org/model` form. Browse the catalog at [tokenfactory.nebius.com](https://tokenfactory.nebius.com/) or the [Models guides](../../models/) in this cookbook.
+Model IDs use the `org/model` form. The default above was present in the public
+catalog when this recipe was checked; use `NEBIUS_CHAT_MODEL` to select another
+model without editing the example. Browse the
+[live catalog](https://tokenfactory.nebius.com/) before running because model
+availability is lifecycle-dependent.
 
 ## 4. Embeddings
 
-Token Factory currently serves `Qwen/Qwen3-Embedding-8B`. By default it returns **4096-dimensional** vectors, which exceed Pixeltable’s embedding-index limit of 4000. Request a truncated size when you need an index:
+Token Factory currently serves `Qwen/Qwen3-Embedding-8B`. By default it returns
+**4096-dimensional** vectors, which exceed Pixeltable’s embedding-index limit
+of 4000. Request a truncated size when you need an index:
 
 ```python
 emb_t = pxt.create_table('nebius_demo/embeddings', {'input': pxt.String})
@@ -88,8 +109,12 @@ emb_t.select(emb_t.input, sim=sim).order_by(sim, asc=False).collect()
 ## Troubleshooting
 
 - **401 Unauthorized** — confirm `NEBIUS_API_KEY` is set in the environment.
-- **404 / model not found** — check the model ID (`org/model`, case-sensitive) against your Token Factory catalog.
-- **Embedding index errors** — use `model_kwargs={'dimensions': 1024}` (or another size ≤ 4000) with `Qwen/Qwen3-Embedding-8B`.
+- **404 / model not found** — check the model ID (`org/model`, case-sensitive)
+  against your Token Factory catalog.
+- **Embedding index errors** — use `model_kwargs={'dimensions': 1024}` (or
+  another size ≤ 4000) with `Qwen/Qwen3-Embedding-8B`.
+- **Different chat model** — export `NEBIUS_CHAT_MODEL=org/model` after checking
+  that the selected model supports the features you use.
 
 ## Resources
 

--- a/integrations/pixeltable/test_pixeltable_recipe.py
+++ b/integrations/pixeltable/test_pixeltable_recipe.py
@@ -1,0 +1,38 @@
+import ast
+import re
+import unittest
+from pathlib import Path
+
+
+README = Path(__file__).with_name('README.md')
+
+
+class PixeltableRecipeTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.text = README.read_text(encoding='utf-8')
+
+    def test_python_blocks_compile(self) -> None:
+        blocks = re.findall(r'```python\n(.*?)```', self.text, flags=re.DOTALL)
+        self.assertGreaterEqual(len(blocks), 2)
+        for block in blocks:
+            ast.parse(block)
+
+    def test_secret_is_not_assigned_in_python(self) -> None:
+        self.assertNotRegex(self.text, r"os\.environ\[['\"]NEBIUS_API_KEY['\"]\]\s*=")
+        self.assertIn('export NEBIUS_API_KEY=your_key_here', self.text)
+
+    def test_model_is_overridable(self) -> None:
+        self.assertRegex(self.text, r"os\.getenv\(\s*'NEBIUS_CHAT_MODEL'")
+        self.assertIn('model=CHAT_MODEL', self.text)
+
+    def test_native_route_is_named_without_responses_claim(self) -> None:
+        self.assertIn('native Nebius Token Factory provider', self.text)
+        self.assertRegex(
+            self.text,
+            r'does not add\s+another provider or claim Responses API support',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What changed

- pin the documented verification target to Pixeltable 0.7.1 and record the 2026-08-13 check date
- remove the suggestion to save `NEBIUS_API_KEY` in Python/notebook source
- make the current chat model configurable through `NEBIUS_CHAT_MODEL` while keeping the existing catalog-backed default
- state the exact ownership boundary: this uses Pixeltable's native Chat Completions UDFs and does not add a provider or claim Responses API support
- add four offline tests for Python snippet syntax, secret hygiene, model override wiring, and native-route labeling
- bring the existing guide through markdownlint

## Why

Pixeltable already owns a native Nebius provider, so no adapter should be duplicated here. The useful gap is a safer, versioned, lifecycle-aware recipe with executable checks. The model remains overridable because catalog availability changes; this PR does not guess at models whose deprecation is only proposed.

I searched the cookbook's open PRs and found no change touching `integrations/pixeltable`.

## Validation

- `python3 -m unittest integrations/pixeltable/test_pixeltable_recipe.py -v` — 4 passed
- installed `pixeltable==0.7.1` plus `openai` in an isolated Python 3.11 environment and verified its native Nebius module contains the canonical `https://api.tokenfactory.nebius.com/v1` route, `NEBIUS_API_KEY`, `chat_completions`, and `embeddings`
- `python3 -m compileall -q integrations/pixeltable`
- `npx --yes markdownlint-cli2 integrations/pixeltable/README.md` — 0 issues
- `git diff --check`

No API key or paid live inference was used.
