### PR TITLE
fix(snake-game): keep API credentials server-side

### DIFF
--- a/fun/snake-game/CLAUDE.md
+++ b/fun/snake-game/CLAUDE.md
@@ -66,7 +66,8 @@ This is a snake battle game with AI-controlled opponents powered by LLM APIs. Th
 5. Ensure all critical bugs are fixed before adding new features
 
 ## Critical Files
-- `snake-1.html`: Main UI structure (maintain careful balance of div tags)
+- `snake.html`: Main UI structure (maintain careful balance of div tags)
+- `server.py`: Loopback-only, allowlisted API proxy; never move credentials into browser code
 - `style.css`: Layout and styling (preserve flex layouts and panel dimensions)
 - `game.js`: Game logic and performance optimizations
 - `benchmark.js`: Model performance testing

--- a/fun/snake-game/README.md
+++ b/fun/snake-game/README.md
@@ -159,6 +159,8 @@ export TOKEN_FACTORY_BASE_URL='https://example.com/v1/'
 python3 server.py
 ```
 
+`OPENAI_API_KEY` is read only when `TOKEN_FACTORY_BASE_URL` is explicitly set;
+an ambient OpenAI key is never sent to the default Nebius endpoint.
 `TOKEN_FACTORY_BASE_URL` must be an absolute HTTP(S) URL without embedded
 credentials, query parameters, or fragments. The browser can only call the
 proxy's allowlisted `/api/models` and `/api/chat/completions` routes; it cannot

--- a/fun/snake-game/README.md
+++ b/fun/snake-game/README.md
@@ -159,10 +159,13 @@ export TOKEN_FACTORY_BASE_URL='https://example.com/v1/'
 python3 server.py
 ```
 
-`OPENAI_API_KEY` is read only when `TOKEN_FACTORY_BASE_URL` is explicitly set;
-an ambient OpenAI key is never sent to the default Nebius endpoint.
+`OPENAI_API_KEY` is required when `TOKEN_FACTORY_BASE_URL` is explicitly set;
+the server never falls back to `NEBIUS_API_KEY` for a custom upstream, and an
+ambient OpenAI key is never sent to the default Nebius endpoint.
 `TOKEN_FACTORY_BASE_URL` must be an absolute HTTP(S) URL without embedded
-credentials, query parameters, or fragments. The browser can only call the
+credentials, query parameters, or fragments. Custom network endpoints must use
+HTTPS; plain HTTP is accepted only for `localhost`, `127.0.0.1`, or `::1` local
+providers. The browser can only call the
 proxy's allowlisted `/api/models` and `/api/chat/completions` routes; it cannot
 choose an arbitrary upstream URL. The server binds to `127.0.0.1` and does not
 enable CORS.

--- a/fun/snake-game/README.md
+++ b/fun/snake-game/README.md
@@ -12,12 +12,12 @@ A visual snake battle game where two LLMs compete against each other! Watch as A
 - **Real-time Visualization**: Watch the snakes move, grow, and compete on a 30×30 canvas
 - **Game Log**: Per-move event tracking with color-coded API latency (teal/yellow/red) and smart auto-scroll
 - **Latency Graphs**: Interactive per-player time-series graph (hover for exact move + latency) with Min/Median/P90/Max stats
-- **Configurable**: Choose models from any OpenAI-compatible API
+- **Configurable**: Choose models from any OpenAI-compatible API through a local, server-side proxy
 - **Loop Mode**: Auto-restart with a 5-second countdown after each game ends (on by default)
 - **Collision Avoidance Toggle**: Enable/disable LLM safe-move hints and automatic override (on by default)
 - **Thinking Mode**: Optionally let models reason before answering via `enable_thinking` (off by default)
 - **Visibility Radius**: Adjustable snake vision (1–30 cells, default 5; 30 = full grid)
-- **Debug Mode**: Console logging with masked auth headers and timestamped request/response correlation
+- **Debug Mode**: Timestamped request/response correlation without exposing auth headers to the browser
 - **Model Benchmarking**: Dual-benchmark Speed Test with tabbed results, sortable headers, and sort-by-benchmark menu
 - **Capped Game Log**: Keeps the 100 most recent entries (older ones trimmed) to stay light over long games
 - **Fancy UI**: Dark theme with glowing effects and glass panels
@@ -35,13 +35,35 @@ A visual snake battle game where two LLMs compete against each other! Watch as A
 
 ## How to Play
 
-1. Open `snake.html` in your web browser
-2. Enter your **API URL** (already filled with Nebius Token Factory endpoint)
-3. Paste your **API Key**
-4. Click **Load Models** to fetch available models
-5. Select different models for Player 1 (Red) and Player 2 (Blue) via the searchable dropdowns
-6. (Optional) Adjust **Options** — Visibility Radius, Collision Avoidance, Thinking Mode, Debug Mode
-7. Click **Start** to begin the battle
+1. Set the API key in your current terminal session:
+
+   ```bash
+   read -rsp 'Nebius API key: ' NEBIUS_API_KEY && echo
+   export NEBIUS_API_KEY
+   ```
+
+2. Start the loopback-only game server from this directory:
+
+   ```bash
+   python3 server.py
+   ```
+
+3. Open <http://127.0.0.1:8000/snake.html>.
+4. Click **Load Models** to fetch available models.
+5. Select different models for Player 1 (Red) and Player 2 (Blue) via the searchable dropdowns.
+6. (Optional) Adjust **Options** — Visibility Radius, Collision Avoidance, Thinking Mode, Debug Mode.
+7. Click **Start** to begin the battle.
+
+The API key remains in the Python process. It is never placed in HTML, browser
+storage, browser JavaScript, or a client-side `Authorization` header. Do not
+commit keys to this repository. Stop the server and `unset NEBIUS_API_KEY` when
+you are finished if the shell is shared.
+
+Run the offline proxy/security checks with:
+
+```bash
+python3 -m unittest -v test_server.py
+```
 
 Controls in the left pane: **Start**, **Pause** ⏸️, **Restart** 🔄, and a **Loop** toggle. The **🔧 Extra** section has the **Speed Test** benchmark and sort buttons.
 
@@ -82,7 +104,7 @@ Controls in the left pane: **Start**, **Pause** ⏸️, **Restart** 🔄, and a 
 
 ## Tech Stack
 
-- Pure HTML/CSS/JavaScript (no build tools required)
+- HTML/CSS/JavaScript frontend with a Python standard-library localhost proxy
 - Canvas API for game rendering
 - OpenAI-compatible API for LLM calls
 - Responsive design (stacks vertically on narrow screens)
@@ -94,6 +116,8 @@ Controls in the left pane: **Start**, **Pause** ⏸️, **Restart** 🔄, and a 
 ├── style.css       # Styling and animations
 ├── game.js         # Game logic, rendering, and API integration
 ├── benchmark.js    # Model performance testing system
+├── server.py       # Static server + narrow server-side API proxy
+├── test_server.py  # Proxy/security regression tests
 └── README.md       # This file
 ```
 
@@ -120,20 +144,39 @@ const MAX_LOG_ENTRIES = 100;          // Cap on game-log <p> entries (oldest tri
 
 ## API Compatibility
 
-Works with any OpenAI-compatible API that supports:
+The server defaults to Nebius Token Factory. It works with any OpenAI-compatible
+API that supports:
 - `GET /models` endpoint (verbose metadata is tried first for modality filtering, with plain fallback)
 - `POST /chat/completions` endpoint
 - Standard message format
 
-Tested with Nebius Token Factory but should work with others (OpenAI, compatible proxies, Ollama, LM Studio). Models are filtered by **output modality**: any model that produces text output is included (so vision-capable text LLMs like `moonshotai/Kimi-K2.6` are selectable), while pure image/audio generation models are excluded.
+To use another endpoint, configure it on the server, not in the browser:
+
+```bash
+read -rsp 'Provider API key: ' OPENAI_API_KEY && echo
+export OPENAI_API_KEY
+export TOKEN_FACTORY_BASE_URL='https://example.com/v1/'
+python3 server.py
+```
+
+`TOKEN_FACTORY_BASE_URL` must be an absolute HTTP(S) URL without embedded
+credentials, query parameters, or fragments. The browser can only call the
+proxy's allowlisted `/api/models` and `/api/chat/completions` routes; it cannot
+choose an arbitrary upstream URL. The server binds to `127.0.0.1` and does not
+enable CORS.
+
+Models are filtered by **output modality**: any model that produces text output
+is included (so vision-capable text LLMs like `moonshotai/Kimi-K2.6` are
+selectable), while pure image/audio generation models are excluded.
 
 ## Troubleshooting
 
 **"Failed to load models" error:**
-- Check your API URL ends with `/`
-- Verify your API key is correct
+- Confirm you opened the game through `python3 server.py`, not as a `file://` URL
+- Check that `NEBIUS_API_KEY` or `OPENAI_API_KEY` was exported before the server started
+- If using a custom provider, verify `TOKEN_FACTORY_BASE_URL`
+- Read the server terminal for an upstream HTTP status
 - Check browser console (F12) for detailed errors
-- Some APIs require CORS to be configured to work from the browser
 
 **Snakes don't seem smart:**
 - Try different models - some are better at this task than others

--- a/fun/snake-game/benchmark.js
+++ b/fun/snake-game/benchmark.js
@@ -658,13 +658,13 @@ class ModelBenchmark {
         }
     }
 
-    async benchmarkThinking1Model(apiUrl, apiKey, modelName, testCount = ModelBenchmark.TEST_COUNT, thinkingEnabled = false) {
+    async benchmarkThinking1Model(apiUrl, modelName, testCount = ModelBenchmark.TEST_COUNT, thinkingEnabled = false) {
         console.log(`\n🎯 [Bench 2] Starting thinking-1 (random line) benchmark for model: ${this.getDisplayName(modelName)}`);
         console.log(`   Running ${testCount} parallel test requests...`);
 
         const results = [];
         const requests = Array.from({ length: testCount }, () =>
-            this.performUUIDRequest(apiUrl, apiKey, modelName, thinkingEnabled)
+            this.performUUIDRequest(apiUrl, modelName, thinkingEnabled)
         );
 
         const requestResults = await Promise.all(requests);
@@ -782,13 +782,13 @@ class ModelBenchmark {
      * token (then aborts). No max_tokens cap, no accuracy dimension — success
      * is simply "the model started emitting output within the timeout."
      */
-    async benchmarkResponseTimeModel(apiUrl, apiKey, modelName, testCount = ModelBenchmark.PURE_SPEED_TEST_COUNT, thinkingEnabled = false) {
+    async benchmarkResponseTimeModel(apiUrl, modelName, testCount = ModelBenchmark.PURE_SPEED_TEST_COUNT, thinkingEnabled = false) {
         console.log(`\n⚡ [Bench 1] Starting response-time benchmark for model: ${this.getDisplayName(modelName)}`);
         console.log(`   Running ${testCount} parallel first-token-arrival (streaming) tests...`);
 
         const results = [];
         const requests = Array.from({ length: testCount }, () =>
-            this.performPureSpeedRequest(apiUrl, apiKey, modelName, thinkingEnabled)
+            this.performPureSpeedRequest(apiUrl, modelName, thinkingEnabled)
         );
 
         const requestResults = await Promise.all(requests);
@@ -893,7 +893,7 @@ class ModelBenchmark {
      * Success = at least one content delta came back. Failure = non-200 HTTP,
      * a network/parse error, timeout, or the stream ended with no content.
      */
-    async performPureSpeedRequest(apiUrl, apiKey, modelName, thinkingEnabled = false) {
+    async performPureSpeedRequest(apiUrl, modelName, thinkingEnabled = false) {
         const systemPrompt = `You are a test endpoint.`;
         const userPrompt = ModelBenchmark.PURE_SPEED_PROMPT;
 
@@ -909,8 +909,7 @@ class ModelBenchmark {
             const response = await fetch(`${apiUrl}chat/completions`, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${apiKey}`
+                    'Content-Type': 'application/json'
                 },
                 signal: abortController.signal,
                 body: JSON.stringify({
@@ -1010,7 +1009,7 @@ class ModelBenchmark {
         return typeof delta === 'string' && delta.length > 0;
     }
 
-    async performUUIDRequest(apiUrl, apiKey, modelName, thinkingEnabled = false) {
+    async performUUIDRequest(apiUrl, modelName, thinkingEnabled = false) {
         try {
             // Fallback for crypto.randomUUID() in older browsers
             const generateUUID = () => {
@@ -1048,8 +1047,7 @@ class ModelBenchmark {
                     fetch(`${apiUrl}chat/completions`, {
                         method: 'POST',
                         headers: {
-                            'Content-Type': 'application/json',
-                            'Authorization': `Bearer ${apiKey}`
+                            'Content-Type': 'application/json'
                         },
                         body: JSON.stringify({
                             model: modelName,
@@ -1270,17 +1268,9 @@ document.addEventListener('DOMContentLoaded', () => {
             // Disable button immediately
             benchmarkBtn.disabled = true;
 
-            const apiUrl = document.getElementById('api-url').value;
-            const apiKey = document.getElementById('api-key').value;
+            const apiUrl = API_BASE_URL;
             // Mirror the Options toggle so benchmarks compare the same setting used in-game
             const thinkingEnabled = document.getElementById('thinking-mode-checkbox')?.checked ?? false;
-
-            if (!apiUrl || !apiKey) {
-                console.error('❌ Please provide API URL and API key');
-                alert('Please provide API URL and API key');
-                benchmarkBtn.disabled = false;
-                return;
-            }
 
             // Access availableModels from game.js
             if (typeof availableModels === 'undefined' || availableModels.length === 0) {
@@ -1318,7 +1308,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                     await Promise.allSettled(availableModels.map(model =>
                         // Count omitted so each runner applies its own default
-                        runner.call(benchmark, apiUrl, apiKey, model.id, undefined, thinkingEnabled)
+                        runner.call(benchmark, apiUrl, model.id, undefined, thinkingEnabled)
                     ));
                 }
 

--- a/fun/snake-game/game.js
+++ b/fun/snake-game/game.js
@@ -20,6 +20,7 @@ const SYSTEM_FONT = '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Aria
 // top as new ones are added, so a long single game (or a resumed loop session)
 // can't accumulate unbounded nodes. Reset on restart/loop round still wipes all.
 const MAX_LOG_ENTRIES = 100;
+const API_BASE_URL = '/api/';
 
 // LLM Configuration
 // If true, passes the full GRID_SIZE x GRID_SIZE board to the LLM
@@ -120,8 +121,7 @@ let gameState = {
     player1ConsecutiveFailures: 0,
     player2ConsecutiveFailures: 0,
     turnDelay: 0,
-    apiUrl: '',
-    apiKey: '',
+    apiUrl: API_BASE_URL,
     player1Model: '',
     player2Model: '',
     debugMode: false,
@@ -143,8 +143,6 @@ let gameState = {
 };
 
 // DOM Elements
-const apiUrlInput = document.getElementById('api-url');
-const apiKeyInput = document.getElementById('api-key');
 const loadModelsBtn = document.getElementById('load-models-btn');
 const loadingDiv = document.getElementById('loading');
 const modelsLoadedCount = document.getElementById('models-loaded-count');
@@ -615,33 +613,6 @@ if (fruitLegendBtn) {
     });
 }
 
-// Normalize API URL - ensure trailing slash
-function normalizeApiUrl(url) {
-    if (!url) return '';
-    return url.endsWith('/') ? url : url + '/';
-}
-
-// Validate API URL format
-function isValidApiUrl(url) {
-    try {
-        // Check if it's a valid HTTPS URL
-        const parsedUrl = new URL(url);
-        return parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:';
-    } catch (e) {
-        return false;
-    }
-}
-
-// Validate API key format
-function isValidApiKey(apiKey) {
-    if (!apiKey || apiKey.length < 10) {
-        return false;
-    }
-    // Check for reasonable character set (letters, numbers, symbols)
-    const apiKeyRegex = /^[A-Za-z0-9\-_\.]+$/;
-    return apiKeyRegex.test(apiKey);
-}
-
 // Filter models to text-to-text only
 function filterTextModels(models) {
     console.log(`🎯 Filtering ${models.length} models to text-to-text only...`);
@@ -697,31 +668,10 @@ function isNonTextModel(modelId) {
 
 // Load models from API
 async function loadModels() {
-    const apiUrl = normalizeApiUrl(apiUrlInput.value.trim());
-    const apiKey = apiKeyInput.value.trim();
+    const apiUrl = API_BASE_URL;
 
     // Clear any previous error messages
     clearError();
-
-    if (!apiUrl) {
-        showError('Please enter an API URL');
-        return;
-    }
-
-    if (!isValidApiUrl(apiUrl)) {
-        showError('Please enter a valid API URL (e.g., https://api.example.com/v1/)');
-        return;
-    }
-
-    if (!apiKey) {
-        showError('Please enter an API key');
-        return;
-    }
-
-    if (!isValidApiKey(apiKey)) {
-        showError('Please enter a valid API key');
-        return;
-    }
 
     loadingDiv.classList.remove('hidden');
 
@@ -735,9 +685,6 @@ async function loadModels() {
             console.log('🔄 Attempting to fetch models with verbose=true...');
             response = await fetch(`${apiUrl}models?verbose=true`, {
                 method: 'GET',
-                headers: {
-                    'Authorization': `Bearer ${apiKey}`
-                },
                 credentials: 'omit'
             });
 
@@ -772,9 +719,6 @@ async function loadModels() {
             console.log('ℹ️ Verbose request failed or not supported, falling back to standard request');
             response = await fetch(`${apiUrl}models`, {
                 method: 'GET',
-                headers: {
-                    'Authorization': `Bearer ${apiKey}`
-                },
                 credentials: 'omit'
             });
 
@@ -2366,8 +2310,7 @@ async function getLLMDirection(playerNum, maxTokens = null) {
             console.log(`[${formatTimestamp(new Date(startTime))}] ======== P${playerNum}: Move ${playerMove}: Request ${requestNum} (${requestBytes} bytes, ~${requestTokens} tokens) ======`);
             console.log('URL:', `${gameState.apiUrl}chat/completions`);
             console.log('Headers:', {
-                'Content-Type': 'application/json',
-                'Authorization': 'Bearer ***HIDDEN***'
+                'Content-Type': 'application/json'
             });
             console.log('Body:', JSON.stringify(requestBody, null, 2));
         }
@@ -2377,8 +2320,7 @@ async function getLLMDirection(playerNum, maxTokens = null) {
             response = await fetch(`${gameState.apiUrl}chat/completions`, {
                 method: 'POST',
                 headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${gameState.apiKey}`
+                    'Content-Type': 'application/json'
                 },
                 body: JSON.stringify(requestBody),
                 signal: abortController.signal,
@@ -3680,8 +3622,7 @@ function startGame(fromDemoMode = false) {
         return;
     }
 
-    gameState.apiUrl = normalizeApiUrl(apiUrlInput.value.trim());
-    gameState.apiKey = apiKeyInput.value.trim();
+    gameState.apiUrl = API_BASE_URL;
 
     if (!gameState.player1Model || !gameState.player2Model) {
         showError('Please select both player models');

--- a/fun/snake-game/server.py
+++ b/fun/snake-game/server.py
@@ -38,6 +38,14 @@ def normalize_base_url(value: str) -> str:
         raise ValueError(
             "TOKEN_FACTORY_BASE_URL must not contain credentials, query, or fragment"
         )
+    if parsed.scheme != "https" and parsed.hostname not in {
+        "127.0.0.1",
+        "localhost",
+        "::1",
+    }:
+        raise ValueError(
+            "TOKEN_FACTORY_BASE_URL must use HTTPS unless it is loopback-only"
+        )
     path = parsed.path.rstrip("/") + "/"
     return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
 
@@ -46,11 +54,9 @@ def resolve_config(environ: Mapping[str, str]) -> tuple[str, str]:
     """Resolve an endpoint and its matching key without ambient-key confusion."""
     custom_base_url = environ.get("TOKEN_FACTORY_BASE_URL")
     if custom_base_url:
-        api_key = environ.get("OPENAI_API_KEY") or environ.get("NEBIUS_API_KEY")
+        api_key = environ.get("OPENAI_API_KEY")
         if not api_key:
-            raise ValueError(
-                "Set OPENAI_API_KEY (or NEBIUS_API_KEY) for TOKEN_FACTORY_BASE_URL."
-            )
+            raise ValueError("Set OPENAI_API_KEY for TOKEN_FACTORY_BASE_URL.")
         return api_key, normalize_base_url(custom_base_url)
 
     api_key = environ.get("NEBIUS_API_KEY")

--- a/fun/snake-game/server.py
+++ b/fun/snake-game/server.py
@@ -11,6 +11,7 @@ import argparse
 import json
 import os
 import sys
+from collections.abc import Mapping
 from http import HTTPStatus
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -39,6 +40,23 @@ def normalize_base_url(value: str) -> str:
         )
     path = parsed.path.rstrip("/") + "/"
     return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def resolve_config(environ: Mapping[str, str]) -> tuple[str, str]:
+    """Resolve an endpoint and its matching key without ambient-key confusion."""
+    custom_base_url = environ.get("TOKEN_FACTORY_BASE_URL")
+    if custom_base_url:
+        api_key = environ.get("OPENAI_API_KEY") or environ.get("NEBIUS_API_KEY")
+        if not api_key:
+            raise ValueError(
+                "Set OPENAI_API_KEY (or NEBIUS_API_KEY) for TOKEN_FACTORY_BASE_URL."
+            )
+        return api_key, normalize_base_url(custom_base_url)
+
+    api_key = environ.get("NEBIUS_API_KEY")
+    if not api_key:
+        raise ValueError("Set NEBIUS_API_KEY before starting the server.")
+    return api_key, DEFAULT_BASE_URL
 
 
 class SnakeGameServer(ThreadingHTTPServer):
@@ -214,16 +232,8 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
-    api_key = os.environ.get("NEBIUS_API_KEY") or os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        print(
-            "Set NEBIUS_API_KEY (or OPENAI_API_KEY) before starting the server.",
-            file=sys.stderr,
-        )
-        return 2
-
-    base_url = os.environ.get("TOKEN_FACTORY_BASE_URL", DEFAULT_BASE_URL)
     try:
+        api_key, base_url = resolve_config(os.environ)
         server = SnakeGameServer(("127.0.0.1", args.port), api_key, base_url)
     except ValueError as error:
         print(error, file=sys.stderr)

--- a/fun/snake-game/server.py
+++ b/fun/snake-game/server.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Serve the snake game and proxy its two OpenAI-compatible API routes.
+
+The browser never receives the API key. The proxy is intentionally bound to
+loopback and only forwards the exact routes used by the demo.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from http import HTTPStatus
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlsplit, urlunsplit
+from urllib.request import Request, urlopen
+
+DEFAULT_BASE_URL = "https://api.tokenfactory.nebius.com/v1/"
+MAX_REQUEST_BYTES = 2 * 1024 * 1024
+PROXY_ROUTES = {
+    "/api/models": ("GET", "models"),
+    "/api/chat/completions": ("POST", "chat/completions"),
+}
+FORWARDED_RESPONSE_HEADERS = {"content-type", "cache-control"}
+STATIC_DIR = Path(__file__).resolve().parent
+
+
+def normalize_base_url(value: str) -> str:
+    """Return a normalized HTTP(S) API base URL without query or fragment."""
+    parsed = urlsplit(value.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("TOKEN_FACTORY_BASE_URL must be an absolute HTTP(S) URL")
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError(
+            "TOKEN_FACTORY_BASE_URL must not contain credentials, query, or fragment"
+        )
+    path = parsed.path.rstrip("/") + "/"
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+class SnakeGameServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, address: tuple[str, int], api_key: str, base_url: str):
+        self.api_key = api_key
+        self.base_url = normalize_base_url(base_url)
+        super().__init__(address, SnakeGameHandler)
+
+
+class SnakeGameHandler(SimpleHTTPRequestHandler):
+    """Static-file handler with a narrow, same-origin API proxy."""
+
+    server: SnakeGameServer
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(STATIC_DIR), **kwargs)
+
+    def end_headers(self) -> None:
+        self.send_header("X-Content-Type-Options", "nosniff")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("Cross-Origin-Resource-Policy", "same-origin")
+        self.send_header("Cache-Control", "no-store")
+        self.send_header(
+            "Content-Security-Policy",
+            "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; "
+            "script-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'; "
+            "frame-ancestors 'none'",
+        )
+        super().end_headers()
+
+    def do_GET(self) -> None:
+        if not self._allow_local_host():
+            return
+        if self.path == "/":
+            self.send_response(HTTPStatus.FOUND)
+            self.send_header("Location", "/snake.html")
+            self.end_headers()
+            return
+        if urlsplit(self.path).path.startswith("/api/"):
+            self._proxy("GET")
+            return
+        super().do_GET()
+
+    def do_POST(self) -> None:
+        if not self._allow_local_host():
+            return
+        if urlsplit(self.path).path.startswith("/api/"):
+            self._proxy("POST")
+            return
+        self._send_json_error(HTTPStatus.NOT_FOUND, "Not found")
+
+    def do_OPTIONS(self) -> None:
+        if not self._allow_local_host():
+            return
+        # Deliberately omit CORS support: browser calls must be same-origin.
+        self._send_json_error(HTTPStatus.METHOD_NOT_ALLOWED, "CORS is not enabled")
+
+    def _allow_local_host(self) -> bool:
+        """Reject DNS-rebinding requests that use a non-local Host header."""
+        try:
+            hostname = urlsplit("//" + self.headers.get("Host", "")).hostname
+        except ValueError:
+            hostname = None
+        if hostname not in {"127.0.0.1", "localhost"}:
+            self._send_json_error(HTTPStatus.FORBIDDEN, "Use a localhost URL")
+            return False
+        return True
+
+    def _proxy(self, method: str) -> None:
+        parsed = urlsplit(self.path)
+        route = PROXY_ROUTES.get(parsed.path)
+        if route is None:
+            self._send_json_error(HTTPStatus.NOT_FOUND, "Unsupported API route")
+            return
+
+        allowed_method, upstream_path = route
+        if method != allowed_method:
+            self._send_json_error(HTTPStatus.METHOD_NOT_ALLOWED, "Method not allowed")
+            return
+
+        body = None
+        if method == "POST":
+            if self.headers.get_content_type() != "application/json":
+                self._send_json_error(
+                    HTTPStatus.UNSUPPORTED_MEDIA_TYPE, "Expected application/json"
+                )
+                return
+            try:
+                content_length = int(self.headers.get("Content-Length", "0"))
+            except ValueError:
+                self._send_json_error(HTTPStatus.BAD_REQUEST, "Invalid Content-Length")
+                return
+            if content_length <= 0 or content_length > MAX_REQUEST_BYTES:
+                self._send_json_error(
+                    HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Invalid request size"
+                )
+                return
+            body = self.rfile.read(content_length)
+            try:
+                payload = json.loads(body)
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                self._send_json_error(
+                    HTTPStatus.BAD_REQUEST, "Request body must be valid JSON"
+                )
+                return
+            if not isinstance(payload, dict):
+                self._send_json_error(
+                    HTTPStatus.BAD_REQUEST, "Request body must be a JSON object"
+                )
+                return
+
+        query = parsed.query if upstream_path == "models" else ""
+        upstream_url = self.server.base_url + upstream_path
+        if query:
+            upstream_url += "?" + query
+
+        headers = {
+            "Authorization": f"Bearer {self.server.api_key}",
+            "Accept": self.headers.get("Accept", "application/json"),
+            "User-Agent": "nebius-token-factory-snake-game/1.0",
+        }
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+
+        request = Request(upstream_url, data=body, headers=headers, method=method)
+        try:
+            with urlopen(request, timeout=45) as response:
+                self._relay_response(response.status, response.headers, response)
+        except HTTPError as error:
+            with error:
+                self._relay_response(error.code, error.headers, error)
+        except (URLError, TimeoutError) as error:
+            reason = error.reason if isinstance(error, URLError) else "timeout"
+            self._send_json_error(
+                HTTPStatus.BAD_GATEWAY, f"Upstream request failed: {reason}"
+            )
+
+    def _relay_response(self, status: int, headers, response) -> None:
+        self.send_response(status)
+        for name, value in headers.items():
+            if name.lower() in FORWARDED_RESPONSE_HEADERS:
+                self.send_header(name, value)
+        self.end_headers()
+
+        # read1 allows SSE chat responses to reach the browser incrementally.
+        reader = getattr(response, "read1", response.read)
+        try:
+            while chunk := reader(16 * 1024):
+                self.wfile.write(chunk)
+                self.wfile.flush()
+        except (BrokenPipeError, ConnectionResetError):
+            # Expected when a benchmark aborts after its first streamed token.
+            return
+
+    def _send_json_error(self, status: HTTPStatus, message: str) -> None:
+        body = json.dumps({"error": {"message": message}}).encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--port", type=int, default=8000, help="localhost port (default: 8000)"
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    api_key = os.environ.get("NEBIUS_API_KEY") or os.environ.get("OPENAI_API_KEY")
+    if not api_key:
+        print(
+            "Set NEBIUS_API_KEY (or OPENAI_API_KEY) before starting the server.",
+            file=sys.stderr,
+        )
+        return 2
+
+    base_url = os.environ.get("TOKEN_FACTORY_BASE_URL", DEFAULT_BASE_URL)
+    try:
+        server = SnakeGameServer(("127.0.0.1", args.port), api_key, base_url)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 2
+
+    print(f"Snake game: http://127.0.0.1:{args.port}/snake.html")
+    print(f"Proxying the allowlisted API routes to {server.base_url}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/fun/snake-game/snake.html
+++ b/fun/snake-game/snake.html
@@ -15,14 +15,10 @@
 
                 <!-- API Configuration Section -->
                 <div class="config-section">
-                    <div class="input-group">
-                        <label for="api-url">API URL</label>
-                        <input type="text" id="api-url" value="https://api.tokenfactory.nebius.com/v1/" placeholder="Enter API URL">
-                    </div>
-                    <div class="input-group">
-                        <label for="api-key">API Key</label>
-                        <input type="password" id="api-key" placeholder="Paste your API key here">
-                    </div>
+                    <p class="proxy-status">
+                        API access is provided by the local server. Your key stays in the
+                        server process and is never sent to browser JavaScript.
+                    </p>
                     <button id="load-models-btn" class="btn btn-primary">
                         <span class="btn-icon">⚡</span>
                         Load Models

--- a/fun/snake-game/spec-snake-game.md
+++ b/fun/snake-game/spec-snake-game.md
@@ -320,9 +320,11 @@ On game end with `loopMode` on, `startLoopCountdown()` runs a 5s interval; the o
 | Compatible proxy | `{proxy}/v1/` | `OPENAI_API_KEY` |
 
 All require an OpenAI-compatible `/models` and `/chat/completions`. The upstream does not need CORS because only the local Python server contacts it.
-`OPENAI_API_KEY` is only eligible when `TOKEN_FACTORY_BASE_URL` is explicitly
-configured; the default Nebius endpoint requires `NEBIUS_API_KEY` so an ambient
-provider key cannot be sent to the wrong service.
+`OPENAI_API_KEY` is required when `TOKEN_FACTORY_BASE_URL` is explicitly
+configured; a custom upstream never falls back to `NEBIUS_API_KEY`. The default
+Nebius endpoint requires `NEBIUS_API_KEY`, so an ambient provider key cannot be
+sent to the wrong service. Custom upstreams require HTTPS except explicit
+loopback HTTP endpoints (`localhost`, `127.0.0.1`, or `::1`).
 
 ---
 

--- a/fun/snake-game/spec-snake-game.md
+++ b/fun/snake-game/spec-snake-game.md
@@ -36,7 +36,7 @@ snake-battle/
 
 ### LLM Integration
 
-- **Endpoints:** `GET {apiUrl}models` (load; tries `?verbose=true` first for modality metadata, falls back to plain `/models`); `POST {apiUrl}chat/completions` (decisions).
+- **Browser endpoints:** same-origin `GET /api/models` (load; tries `?verbose=true` first for modality metadata, falls back to plain `/models`) and `POST /api/chat/completions` (decisions). `server.py` maps only these two paths to the configured OpenAI-compatible upstream and adds server-side authentication.
 - **Request body:** `{ model, messages:[{system}, {user}], temperature: 0, chat_template_kwargs: { enable_thinking } }` plus `max_tokens` only when non-null. `enable_thinking` mirrors the **Model Reasoning** Options toggle (`thinkingModeEnabled`, default `false`); setting it `false` disables model "thinking" mode (e.g. GLM-5.x) so only the direction answer comes back — harmless for models that don't recognize `chat_template_kwargs`. The benchmark Speed Test sends the same value for apples-to-apples comparison.
 - **System prompt** (`SYSTEM_PROMPT1`): survival goal + instructions to respond with ONLY `up`/`down`/`left`/`right`, no thinking; a `{VISIBILITY_SIZE}` placeholder is replaced with `VIEW_RADIUS * 2 + 1`.
 - **Board state prompt** (`getBoardState`): player color/length/head pos, enemy info, all fruits with value/distance/value-per-distance, closest fruit + length advantage, high-value targets, ASCII board view centered on head (full 30×30 OR `(VIEW_RADIUS*2+1)` square with wrap; legend `@`=head `★`=fruit `R/r`/`B/b`=bodies `.`=empty), per-direction danger checks, and — if `collisionAvoidanceEnabled` — a `Safe moves:` line with a preferred direction toward the closest fruit.
@@ -46,7 +46,7 @@ snake-battle/
 - **Forfeit:** `MAX_CONSECUTIVE_FAILURES = 3` consecutive failures dispatches a `playerForfeited` event and ends the game.
 - **Fallback:** on error/invalid response, direction falls back via `findSafeDirection` (still records a latency sample).
 - **Pause support:** `togglePause` aborts `gameLoopAbortController` (cancels in-flight fetches); resume creates a fresh controller and restarts the loop. Aborted requests are not logged.
-- **Debug mode:** masks the Authorization header, timestamps logs `[HH:MM:SS.mmm]`, correlates request/response with per-player move numbers. `formatTimestamp(date)` helper.
+- **Debug mode:** timestamps logs `[HH:MM:SS.mmm]` and correlates request/response with per-player move numbers. Authentication never exists in browser state or logs. `formatTimestamp(date)` helper.
 
 ### AI Safety (`collisionAvoidanceEnabled`, default on)
 
@@ -88,8 +88,8 @@ Two-column flex (`main-container`, `.left-pane` + `.right-pane`): a **left confi
 │  .left-pane      │  .right-pane                             │
 │  (config, 400px) │  (flex:1)                                │
 │                  │                                          │
-│  API URL         │  ⏱️ M:SS  timer  (#game-timer)           │
-│  API Key         │  ┌────────┬───────────────────┬────────┐ │
+│  Local API note  │  ⏱️ M:SS  timer  (#game-timer)           │
+│                  │  ┌────────┬───────────────────┬────────┐ │
 │  ⚡ Load Models  │  │ Fruit  │   Game Canvas     │ Game   │ │
 │  P1 model search │  │ Legend │   #game-canvas    │ Log    │ │
 │  P2 model search │  │ (left) │   600×600, 30×30  │(right) │ │
@@ -110,7 +110,7 @@ Two-column flex (`main-container`, `.left-pane` + `.right-pane`): a **left confi
 > Inside `.right-pane`, top-to-bottom: timer → `.game-layout` (3 cols) → `.stats-panel` (2 player cards + VS). The stats panel is **below** the game layout, not above.
 
 ### Left pane (config / controls)
-- **API URL** (`#api-url`, pre-filled Nebius), **API Key** (password), **⚡ Load Models** button + spinner/error.
+- Local-proxy security note, **⚡ Load Models** button, spinner, and error display. API endpoint and secret configuration are server-side only.
 - **Searchable model dropdowns** (`.searchable-dropdown`): `.model-search-input` + `.dropdown-options` for P1 and P2 (type-to-filter, case-insensitive, selects first match; invalid free-text reverts on blur). Player labels `🔴 Player 1 (Red Snake)` / `🔵 Player 2 (Blue Snake)`.
 - **Options section** (`#options-section`, collapsible, starts collapsed): Visibility Radius input (1–30, default 5), Collision Avoidance checkbox (on by default), Debug Mode checkbox, Model Reasoning checkbox (off by default — toggles `chat_template_kwargs.enable_thinking`).
 - **Extra section** (`#extra-section`, collapsible, starts collapsed): ⚡ Speed Test, 📈 Show Results, Sort by Name / by Speed buttons.
@@ -160,10 +160,8 @@ P1 - #45: 💥 HEAD-ON COLLISION!
 ### User-configurable (UI)
 | Setting | Default | Range | Description |
 |---------|---------|-------|-------------|
-| API URL | `https://api.tokenfactory.nebius.com/v1/` | — | OpenAI-compatible endpoint (trailing slash normalized) |
-| API Key | — | min 10 chars, `^[A-Za-z0-9\-_\.]+$` | Auth key (password input) |
 | Player 1 / 2 Model | first / second available | — | Searchable dropdown |
-| Debug Mode | off | on/off | Console logging, masked auth |
+| Debug Mode | off | on/off | Console request/response correlation; auth is server-only |
 | Collision Avoidance | on | on/off | Hints + auto safe-move override |
 | Model Reasoning | off | on/off | `chat_template_kwargs.enable_thinking` in API calls (e.g. GLM-5.x thinking mode). Dynamic — next move uses new setting. Also drives the Speed Test. |
 | Visibility Radius | 5 | 1–30 | Snake vision radius in cells (30 = full grid) |
@@ -205,7 +203,7 @@ P1 - #45: 💥 HEAD-ON COLLISION!
   player1ApiFailures, player2ApiFailures,
   player1ConsecutiveFailures, player2ConsecutiveFailures,
   turnDelay,                       // ms delay before loop starts (init 0)
-  apiUrl, apiKey,
+  apiUrl,                          // fixed browser path: /api/
   player1Model, player2Model,
   debugMode,
   overlayDismissed,                // hide overlay on canvas click
@@ -234,7 +232,7 @@ P1 - #45: 💥 HEAD-ON COLLISION!
 **Models**
 - `loadModels()` — GET, verbose-first, `filterTextModels` (text→text only via Nebius `architecture.modality` / OpenAI `capabilities.modalities` / pattern fallback; `isNonTextModel` excludes whisper/tts/audio/image/vision/dall-e/etc.), sort alphabetically, populate selects, dispatch `modelsLoaded`.
 - `populateSearchableDropdown` / `setupSearchableDropdown` — searchable dropdown behavior.
-- `normalizeApiUrl` / `isValidApiUrl` / `isValidApiKey` — validation.
+- `API_BASE_URL` — fixed same-origin browser proxy path.
 
 **Game loop**
 - `gameLoop()` — bail if over/paused; create `AbortController`; fire both `moveSnakeWithLLM` in parallel.
@@ -281,8 +279,9 @@ On game end with `loopMode` on, `startLoopCountdown()` runs a 5s interval; the o
 ## Security & Performance
 
 - **XSS protection:** game log uses safe DOM manipulation; latency spans built as elements with `data-latency-*` attributes (not string injection). User input goes through DOM APIs.
-- **Input validation:** `isValidApiUrl` (http/https), `isValidApiKey` (length + charset), bounds checks on `max_tokens` level and view radius.
-- **API keys:** password input, only in memory, not persisted; Authorization header masked in debug logs.
+- **Input validation:** bounds checks on `max_tokens` level and view radius; proxy enforces JSON, a 2 MiB body limit, exact route/method allowlists, and a validated server-side upstream URL.
+- **API keys:** read only from the server process environment. Browser JavaScript, HTML, storage, and network requests never receive the key or construct an Authorization header.
+- **Local proxy boundary:** binds to `127.0.0.1`, does not enable CORS, and allows only `/api/models` and `/api/chat/completions`.
 - **Redraw optimization:** `needsRedraw` flag — rAF redraws only on state change or when paused/gameOver (for overlay/animation).
 - **Memory:** latency arrays capped at 1000 (oldest shifted); all `setTimeout` ids tracked in `activeTimeouts` and cleared on teardown; `AbortController` aborts in-flight requests on pause/cleanup.
 - **Cleanup:** `cleanupAllResources` / `cleanupGameResources` stop animation, timer, loop countdown, abort controller, clear timeouts, remove tracked listeners, clear latency data.
@@ -312,30 +311,26 @@ On game end with `loopMode` on, `startLoopCountdown()` runs a 5s interval; the o
 
 ---
 
-## API Config Examples
+## Server API Configuration
 
-| Provider | API URL | Notes |
+| Provider | `TOKEN_FACTORY_BASE_URL` | Server key variable |
 |----------|---------|-------|
-| Nebius Token Factory (default) | `https://api.tokenfactory.nebius.com/v1/` | pre-filled |
-| OpenAI | `https://api.openai.com/v1/` | gpt-4o, etc. |
-| Compatible proxy (e.g. Claude) | `{proxy}/v1/` | OpenAI-compat |
-| Ollama | `http://localhost:11434/v1/` | local, key often blank |
-| LM Studio | `http://localhost:1234/v1/` | key `lm-studio` or blank |
+| Nebius Token Factory (default) | `https://api.tokenfactory.nebius.com/v1/` | `NEBIUS_API_KEY` |
+| OpenAI | `https://api.openai.com/v1/` | `OPENAI_API_KEY` |
+| Compatible proxy | `{proxy}/v1/` | `OPENAI_API_KEY` |
 
-All require an OpenAI-compatible `/models` and `/chat/completions`. CORS must be permitted by the provider.
+All require an OpenAI-compatible `/models` and `/chat/completions`. The upstream does not need CORS because only the local Python server contacts it.
 
 ---
 
 ## Running
 
-No build step. Open `snake.html` in a modern browser, enter API URL + key, Load Models, pick models, Start Battle.
-
-Optional dev server:
+No build step. Export the key in the current shell, start the security proxy, then open its localhost URL:
 
 ```bash
-python3 -m http.server 8000   # http://localhost:8000
-# or
-npx serve .
+read -rsp 'Nebius API key: ' NEBIUS_API_KEY && echo
+export NEBIUS_API_KEY
+python3 server.py             # http://127.0.0.1:8000/snake.html
 ```
 
 **Requirements:** Canvas 2D, Fetch API, ES6+ (async/await, arrow fns, template literals, destructuring), Flexbox, `requestAnimationFrame`, `backdrop-filter` (degrades gracefully).

--- a/fun/snake-game/spec-snake-game.md
+++ b/fun/snake-game/spec-snake-game.md
@@ -320,6 +320,9 @@ On game end with `loopMode` on, `startLoopCountdown()` runs a 5s interval; the o
 | Compatible proxy | `{proxy}/v1/` | `OPENAI_API_KEY` |
 
 All require an OpenAI-compatible `/models` and `/chat/completions`. The upstream does not need CORS because only the local Python server contacts it.
+`OPENAI_API_KEY` is only eligible when `TOKEN_FACTORY_BASE_URL` is explicitly
+configured; the default Nebius endpoint requires `NEBIUS_API_KEY` so an ambient
+provider key cannot be sent to the wrong service.
 
 ---
 

--- a/fun/snake-game/style.css
+++ b/fun/snake-game/style.css
@@ -1759,3 +1759,9 @@ body {
     border-color: #4ecdc4 !important;
     color: #fff !important;
 }
+.proxy-status {
+    margin: 0 0 15px;
+    color: #b8c4d6;
+    font-size: 12px;
+    line-height: 1.5;
+}

--- a/fun/snake-game/test_server.py
+++ b/fun/snake-game/test_server.py
@@ -9,7 +9,7 @@ from typing import ClassVar
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
-from server import SnakeGameServer
+from server import DEFAULT_BASE_URL, SnakeGameServer, resolve_config
 
 DEMO_DIR = Path(__file__).resolve().parent
 
@@ -142,6 +142,24 @@ class SnakeGameProxyTest(unittest.TestCase):
             self.assertEqual(
                 response.headers["Cross-Origin-Resource-Policy"], "same-origin"
             )
+
+    def test_default_endpoint_never_uses_an_ambient_openai_key(self) -> None:
+        with self.assertRaisesRegex(ValueError, "NEBIUS_API_KEY"):
+            resolve_config({"OPENAI_API_KEY": "must-not-go-to-nebius"})
+
+        api_key, base_url = resolve_config({"NEBIUS_API_KEY": "nebius-secret"})
+        self.assertEqual(api_key, "nebius-secret")
+        self.assertEqual(base_url, DEFAULT_BASE_URL)
+
+    def test_custom_endpoint_explicitly_enables_openai_key(self) -> None:
+        api_key, base_url = resolve_config(
+            {
+                "TOKEN_FACTORY_BASE_URL": "https://provider.example/v1",
+                "OPENAI_API_KEY": "provider-secret",
+            }
+        )
+        self.assertEqual(api_key, "provider-secret")
+        self.assertEqual(base_url, "https://provider.example/v1/")
 
 
 if __name__ == "__main__":

--- a/fun/snake-game/test_server.py
+++ b/fun/snake-game/test_server.py
@@ -161,6 +161,33 @@ class SnakeGameProxyTest(unittest.TestCase):
         self.assertEqual(api_key, "provider-secret")
         self.assertEqual(base_url, "https://provider.example/v1/")
 
+    def test_custom_endpoint_never_falls_back_to_nebius_key(self) -> None:
+        with self.assertRaisesRegex(ValueError, "OPENAI_API_KEY"):
+            resolve_config(
+                {
+                    "TOKEN_FACTORY_BASE_URL": "https://provider.example/v1",
+                    "NEBIUS_API_KEY": "must-not-go-to-custom-provider",
+                }
+            )
+
+    def test_custom_endpoint_requires_https_except_for_loopback(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must use HTTPS"):
+            resolve_config(
+                {
+                    "TOKEN_FACTORY_BASE_URL": "http://provider.example/v1",
+                    "OPENAI_API_KEY": "provider-secret",
+                }
+            )
+
+        api_key, base_url = resolve_config(
+            {
+                "TOKEN_FACTORY_BASE_URL": "http://localhost:11434/v1",
+                "OPENAI_API_KEY": "local-provider-secret",
+            }
+        )
+        self.assertEqual(api_key, "local-provider-secret")
+        self.assertEqual(base_url, "http://localhost:11434/v1/")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/fun/snake-game/test_server.py
+++ b/fun/snake-game/test_server.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import ClassVar
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from server import SnakeGameServer
+
+DEMO_DIR = Path(__file__).resolve().parent
+
+
+class RecordingUpstreamHandler(BaseHTTPRequestHandler):
+    requests: ClassVar[list[dict]] = []
+
+    def do_GET(self) -> None:
+        self._record_and_reply({"data": [{"id": "test/model"}]})
+
+    def do_POST(self) -> None:
+        length = int(self.headers["Content-Length"])
+        payload = json.loads(self.rfile.read(length))
+        self._record_and_reply({"choices": [{"message": {"content": "up"}}]}, payload)
+
+    def _record_and_reply(self, response: dict, payload: dict | None = None) -> None:
+        self.requests.append(
+            {
+                "path": self.path,
+                "authorization": self.headers.get("Authorization"),
+                "payload": payload,
+            }
+        )
+        body = json.dumps(response).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *_args) -> None:
+        pass
+
+
+class SnakeGameProxyTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        RecordingUpstreamHandler.requests.clear()
+        cls.upstream = ThreadingHTTPServer(("127.0.0.1", 0), RecordingUpstreamHandler)
+        upstream_port = cls.upstream.server_address[1]
+        cls.proxy = SnakeGameServer(
+            ("127.0.0.1", 0),
+            "server-only-secret",
+            f"http://127.0.0.1:{upstream_port}/v1/",
+        )
+        cls.upstream_thread = threading.Thread(
+            target=cls.upstream.serve_forever, daemon=True
+        )
+        cls.proxy_thread = threading.Thread(target=cls.proxy.serve_forever, daemon=True)
+        cls.upstream_thread.start()
+        cls.proxy_thread.start()
+        cls.proxy_url = f"http://127.0.0.1:{cls.proxy.server_address[1]}"
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.proxy.shutdown()
+        cls.upstream.shutdown()
+        cls.proxy.server_close()
+        cls.upstream.server_close()
+
+    def test_models_route_uses_server_side_authorization(self) -> None:
+        request = Request(
+            self.proxy_url + "/api/models?verbose=true",
+            headers={"Authorization": "Bearer browser-secret"},
+        )
+        with urlopen(request) as response:
+            self.assertEqual(json.load(response)["data"][0]["id"], "test/model")
+
+        recorded = RecordingUpstreamHandler.requests[-1]
+        self.assertEqual(recorded["path"], "/v1/models?verbose=true")
+        self.assertEqual(recorded["authorization"], "Bearer server-only-secret")
+
+    def test_chat_route_forwards_json_without_trusting_browser_auth(self) -> None:
+        payload = {
+            "model": "test/model",
+            "messages": [{"role": "user", "content": "move"}],
+        }
+        request = Request(
+            self.proxy_url + "/api/chat/completions",
+            data=json.dumps(payload).encode(),
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer browser-secret",
+            },
+            method="POST",
+        )
+        with urlopen(request) as response:
+            self.assertEqual(
+                json.load(response)["choices"][0]["message"]["content"], "up"
+            )
+
+        recorded = RecordingUpstreamHandler.requests[-1]
+        self.assertEqual(recorded["authorization"], "Bearer server-only-secret")
+        self.assertEqual(recorded["payload"], payload)
+
+    def test_unknown_api_routes_and_cors_are_rejected(self) -> None:
+        for request in (
+            Request(self.proxy_url + "/api/arbitrary"),
+            Request(self.proxy_url + "/api/models", method="OPTIONS"),
+        ):
+            with self.assertRaises(HTTPError) as raised:
+                urlopen(request)
+            self.assertIn(raised.exception.code, {404, 405})
+            raised.exception.close()
+
+    def test_non_local_host_header_is_rejected(self) -> None:
+        request = Request(
+            self.proxy_url + "/api/models", headers={"Host": "attacker.example"}
+        )
+        with self.assertRaises(HTTPError) as raised:
+            urlopen(request)
+        self.assertEqual(raised.exception.code, 403)
+        raised.exception.close()
+
+    def test_static_demo_contains_no_client_side_secret_controls(self) -> None:
+        combined = "\n".join(
+            (DEMO_DIR / filename).read_text()
+            for filename in ("snake.html", "game.js", "benchmark.js")
+        )
+        self.assertNotIn('id="api-key"', combined)
+        self.assertNotIn("Authorization", combined)
+        self.assertNotIn("Bearer ", combined)
+        self.assertNotIn("api.tokenfactory.nebius.com", combined)
+        self.assertIn("/api/", combined)
+
+        with urlopen(self.proxy_url + "/snake.html") as response:
+            self.assertIn(
+                "connect-src 'self'", response.headers["Content-Security-Policy"]
+            )
+            self.assertEqual(
+                response.headers["Cross-Origin-Resource-Policy"], "same-origin"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- remove the API URL and API key controls from the snake game's browser UI
- route model listing, game moves, and benchmarks through a same-origin Python proxy
- keep credentials in `NEBIUS_API_KEY` / `OPENAI_API_KEY` on the server only
- require `NEBIUS_API_KEY` for the default Nebius endpoint and `OPENAI_API_KEY` for an explicitly configured custom upstream; never fall back across providers
- require HTTPS for custom network endpoints, allowing plain HTTP only for explicit loopback providers
- restrict the proxy to `GET /api/models` and `POST /api/chat/completions`
- bind to `127.0.0.1`, reject non-local Host headers and CORS, validate the upstream URL, require JSON, and cap request bodies
- add offline proxy/security regression tests and update the README/spec/run instructions

## Why

The previous demo asked users to paste a real API key into browser JavaScript and sent the resulting bearer credential directly from the browser. Browser-held provider keys can be exposed through devtools, extensions, injected scripts, or accidental client-side logging.

The local proxy preserves the no-build demo flow while moving the trust boundary to a server-side process. The browser now knows only the same-origin `/api/` routes and cannot select an arbitrary upstream.

## Validation

- `python3 -m unittest -v test_server.py` — 9 passed
- `uvx ruff check server.py test_server.py`
- `uvx ruff format --check server.py test_server.py`
- `python3 -m py_compile server.py test_server.py`
- `node --check game.js`
- `node --check benchmark.js`
- verified opening/closing `div` counts remain balanced
- browser layout smoke at `127.0.0.1`: security note, controls, canvas, game log, and stats panels render correctly; no console warnings/errors
- `git diff --check`
- verified the server exits safely when no key is set or the upstream URL is invalid

No live model call was made because no credential was placed in the test environment. The tests use a local fake OpenAI-compatible upstream and verify that browser-supplied authorization is ignored in favor of the server-only key.
