### PR TITLE
docs: repair internal links and keep them checked

### DIFF
--- a/.github/scripts/check_internal_links.py
+++ b/.github/scripts/check_internal_links.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Fail when a tracked Markdown document links to a missing local path."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MARKDOWN_SUFFIXES = {".md", ".mdx"}
+INLINE_LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)\n]+)\)")
+REFERENCE_LINK_RE = re.compile(r"^\s*\[[^\]]+\]:\s*(\S+)", re.MULTILINE)
+HTML_LINK_RE = re.compile(r"(?:href|src)\s*=\s*[\"']([^\"']+)[\"']", re.IGNORECASE)
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+IGNORED_SCHEMES = {
+    "data",
+    "http",
+    "https",
+    "mailto",
+    "tel",
+}
+
+
+@dataclass(frozen=True)
+class BrokenLink:
+    document: Path
+    line: int
+    target: str
+    resolved: Path
+
+
+def tracked_markdown_files() -> list[Path]:
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+    )
+    return sorted(
+        REPO_ROOT / path.decode()
+        for path in result.stdout.split(b"\0")
+        if path and Path(path.decode()).suffix.lower() in MARKDOWN_SUFFIXES
+    )
+
+
+def without_fenced_code(text: str) -> str:
+    kept: list[str] = []
+    in_fence = False
+    fence_marker = ""
+    for line in text.splitlines(keepends=True):
+        match = FENCE_RE.match(line)
+        if match:
+            marker = match.group(1)
+            if not in_fence:
+                in_fence = True
+                fence_marker = marker
+            elif marker == fence_marker:
+                in_fence = False
+                fence_marker = ""
+            kept.append("\n" if line.endswith("\n") else "")
+        elif in_fence:
+            kept.append("\n" if line.endswith("\n") else "")
+        else:
+            kept.append(line)
+    return "".join(kept)
+
+
+def destinations(text: str) -> list[tuple[int, str]]:
+    found: list[tuple[int, str]] = []
+    for pattern in (INLINE_LINK_RE, REFERENCE_LINK_RE, HTML_LINK_RE):
+        for match in pattern.finditer(text):
+            target = match.group(1).strip()
+            if target.startswith("<") and ">" in target:
+                target = target[1 : target.index(">")]
+            elif " " in target:
+                target = target.split(maxsplit=1)[0]
+            found.append((text.count("\n", 0, match.start()) + 1, target))
+    return found
+
+
+def resolve_local_target(document: Path, target: str) -> Path | None:
+    if not target or target.startswith("#"):
+        return None
+
+    parsed = urlsplit(target)
+    if parsed.scheme.lower() in IGNORED_SCHEMES or parsed.netloc:
+        return None
+
+    path_text = unquote(parsed.path)
+    if not path_text:
+        return None
+
+    if path_text.startswith("/"):
+        candidate = REPO_ROOT / path_text.lstrip("/")
+    else:
+        candidate = document.parent / path_text
+    return candidate.resolve()
+
+
+def find_broken_links() -> list[BrokenLink]:
+    broken: list[BrokenLink] = []
+    for document in tracked_markdown_files():
+        text = without_fenced_code(document.read_text(encoding="utf-8"))
+        for line, target in destinations(text):
+            resolved = resolve_local_target(document, target)
+            if resolved is not None and not resolved.exists():
+                broken.append(BrokenLink(document, line, target, resolved))
+    return broken
+
+
+def main() -> int:
+    broken = find_broken_links()
+    if not broken:
+        print("All tracked Markdown internal links resolve.")
+        return 0
+
+    for link in broken:
+        document = link.document.relative_to(REPO_ROOT)
+        try:
+            resolved = link.resolved.relative_to(REPO_ROOT)
+        except ValueError:
+            resolved = link.resolved
+        print(f"{document}:{link.line}: {link.target} -> missing {resolved}")
+    print(f"Found {len(broken)} broken internal link(s).", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/internal-links.yml
+++ b/.github/workflows/internal-links.yml
@@ -1,0 +1,18 @@
+name: Internal links
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check tracked Markdown links
+        run: python3 .github/scripts/check_internal_links.py

--- a/agents/langchain/archived/README-1.md
+++ b/agents/langchain/archived/README-1.md
@@ -6,11 +6,11 @@ This folder contains production-oriented LangChain examples powered by Nebius To
 
 | Example | Production use case | What it demonstrates |
 | --- | --- | --- |
-| [Voice Agent with Gradium](voice-agent-gradium-nebius-langchain/) | Conversational pitch and public-speaking coach | Browser voice turns, Gradium STT/TTS, LangChain prompt orchestration, Nebius reasoning |
-| [Incident Response Agent](incident-response-agent/) | SRE incident triage | Tool-driven log search, runbook lookup, deploy correlation, typed mitigation plan |
-| [Customer Support Resolution Agent](customer-support-resolution-agent/) | CX ticket resolution | KB search, order lookup, policy-grounded draft responses, approval-aware workflow recommendations |
-| [Vendor Risk Compliance Agent](vendor-risk-compliance-agent/) | Security/privacy vendor review | Policy control search, contract evidence review, data-residency checks, risk register output |
-| [Data Quality Ops Agent](data-quality-ops-agent/) | Data operations investigation | Guarded read-only SQL, schema discovery, pipeline change correlation, reproducible data quality report |
+| [Voice Agent with Gradium](../voice-agent-gradium-nebius-langchain/) | Conversational pitch and public-speaking coach | Browser voice turns, Gradium STT/TTS, LangChain prompt orchestration, Nebius reasoning |
+| [Incident Response Agent](../incident-response-agent/) | SRE incident triage | Tool-driven log search, runbook lookup, deploy correlation, typed mitigation plan |
+| [Customer Support Resolution Agent](../customer-support-resolution-agent/) | CX ticket resolution | KB search, order lookup, policy-grounded draft responses, approval-aware workflow recommendations |
+| [Vendor Risk Compliance Agent](../vendor-risk-compliance-agent/) | Security/privacy vendor review | Policy control search, contract evidence review, data-residency checks, risk register output |
+| [Data Quality Ops Agent](../data-quality-ops-agent/) | Data operations investigation | Guarded read-only SQL, schema discovery, pipeline change correlation, reproducible data quality report |
 
 ## Setup pattern
 

--- a/agents/langchain/customer_support_resolution_agent/README.md
+++ b/agents/langchain/customer_support_resolution_agent/README.md
@@ -151,4 +151,4 @@ ticket ID to the customer and the ticket is appended to
 
 ## 📄 License
 
-MIT — see the repo root [LICENSE](../../LICENSE).
+MIT — see the repo root [LICENSE](../../../LICENSE).

--- a/agents/nemotron-agents/README.md
+++ b/agents/nemotron-agents/README.md
@@ -35,7 +35,7 @@ NEBIUS_API_KEY=your-nebius-api-key
 
 ## Run the Agent
 
-file: [esearch_agent_1_nemotron.py](esearch_agent_1_nemotron.py)
+file: [research_agent_1_nemotron.py](research_agent_1_nemotron.py)
 
 Bare deep agent (no external tools):
 
@@ -43,7 +43,7 @@ Bare deep agent (no external tools):
 uv run python research_agent_1_nemotron.py
 ```
 
-The report is written to `output.md`, and a short summary is printed to stdout. You can view a sample output [here](output-sample.md).
+The report is written to `output.md`, and a short summary is printed to stdout. You can view a sample output [here](output-example.md).
 
 ## Run the Agent with Metrics 
 

--- a/fun/snake-game/spec-leaderboard-todo.md
+++ b/fun/snake-game/spec-leaderboard-todo.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-For overall spec see [game-spec.md](game-spec.md)
+For overall spec see [spec-snake-game.md](spec-snake-game.md)
 
 ## Demo mode
 


### PR DESCRIPTION
## Summary

- repair all nine broken local links found on current `main`
- point the archived LangChain index back to its sibling examples
- fix the LICENSE depth, Nemotron filenames, and snake-game spec filename
- add a zero-dependency checker and a small GitHub Actions job so missing local Markdown targets fail future PRs

## Duplicate and overlap check

Audited upstream `main` at `765a709` and every open cookbook PR in the active repair wave (#35 and #37-#55). None of this PR's edited paths is owned by those PRs, and GitHub has no open broken-link/link-checker PR for this repository.

## Validation

- `python3 .github/scripts/check_internal_links.py`
- `python3 -m py_compile .github/scripts/check_internal_links.py`
- `git diff --check`

The checker scans tracked `.md` and `.mdx` files offline, ignores external URLs and fenced code examples, and reports the document line, original destination, and missing resolved path.
