### PR TITLE
Replace legacy studio.nebius URLs with Token Factory endpoints

### DIFF
--- a/agents/langchain/customer-support-resolution-agent/main.py
+++ b/agents/langchain/customer-support-resolution-agent/main.py
@@ -104,7 +104,7 @@ def build_llm() -> Any:
         raise RuntimeError("Set NEBIUS_API_KEY in the environment or this folder's .env file.")
     return ChatOpenAI(
         api_key=key,
-        base_url="https://api.studio.nebius.ai/v1/",
+        base_url="https://api.tokenfactory.nebius.com/v1/",
         model=os.getenv("NEBIUS_MODEL", "moonshotai/Kimi-K2.5"),
         temperature=0.2,
         max_tokens=2400,

--- a/agents/langchain/data-quality-ops-agent/main.py
+++ b/agents/langchain/data-quality-ops-agent/main.py
@@ -135,7 +135,7 @@ def build_llm() -> Any:
         raise RuntimeError("Set NEBIUS_API_KEY in the environment or this folder's .env file.")
     return ChatOpenAI(
         api_key=key,
-        base_url="https://api.studio.nebius.ai/v1/",
+        base_url="https://api.tokenfactory.nebius.com/v1/",
         model=os.getenv("NEBIUS_MODEL", "moonshotai/Kimi-K2.5"),
         temperature=0.1,
         max_tokens=2600,

--- a/agents/langchain/deep-agent-example-1/README.md
+++ b/agents/langchain/deep-agent-example-1/README.md
@@ -79,5 +79,5 @@ uv run python tavily_agent.py
 
 - LangChain Deep Agents: <https://github.com/langchain-ai/deepagents>
 - LangChain Nebius provider: <https://docs.langchain.com/oss/python/integrations/providers/nebius>
-- Nebius Token Factory: <https://studio.nebius.com/>
+- Nebius Token Factory: <https://tokenfactory.nebius.com/>
 - Tavily: <https://tavily.com/>

--- a/agents/langchain/deep-agent-example-1/env.example
+++ b/agents/langchain/deep-agent-example-1/env.example
@@ -1,4 +1,4 @@
-# Nebius Token Factory — https://studio.nebius.com/
+# Nebius Token Factory — https://tokenfactory.nebius.com/
 NEBIUS_API_KEY=your-nebius-api-key
 
 # Tavily web search — https://tavily.com/  (only required for tavily_agent.py)

--- a/agents/langchain/incident-response-agent/main.py
+++ b/agents/langchain/incident-response-agent/main.py
@@ -98,7 +98,7 @@ def build_llm() -> Any:
         raise RuntimeError("Set NEBIUS_API_KEY in the environment or this folder's .env file.")
     return ChatOpenAI(
         api_key=key,
-        base_url="https://api.studio.nebius.ai/v1/",
+        base_url="https://api.tokenfactory.nebius.com/v1/",
         model=os.getenv("NEBIUS_MODEL", "moonshotai/Kimi-K2.5"),
         temperature=0.1,
         max_tokens=2400,

--- a/agents/langchain/vendor-risk-compliance-agent/main.py
+++ b/agents/langchain/vendor-risk-compliance-agent/main.py
@@ -97,7 +97,7 @@ def build_llm() -> Any:
         raise RuntimeError("Set NEBIUS_API_KEY in the environment or this folder's .env file.")
     return ChatOpenAI(
         api_key=key,
-        base_url="https://api.studio.nebius.ai/v1/",
+        base_url="https://api.tokenfactory.nebius.com/v1/",
         model=os.getenv("NEBIUS_MODEL", "moonshotai/Kimi-K2.5"),
         temperature=0.1,
         max_tokens=2600,

--- a/agents/langchain/voice-agent-gradium-nebius-langchain/voice_pitch_coach/coach.py
+++ b/agents/langchain/voice-agent-gradium-nebius-langchain/voice_pitch_coach/coach.py
@@ -59,7 +59,7 @@ class NebiusPitchCoach:
         # LangChain prompt/model flow while targeting Nebius.
         self.llm = ChatOpenAI(
             api_key=api_key,
-            base_url="https://api.studio.nebius.ai/v1/",
+            base_url="https://api.tokenfactory.nebius.com/v1/",
             model=model,
             temperature=0.2,
             top_p=0.95,

--- a/agents/nemotron-agents/README.md
+++ b/agents/nemotron-agents/README.md
@@ -81,5 +81,5 @@ Total tokens:        44,289
 
 - LangChain Deep Agents: <https://github.com/langchain-ai/deepagents>
 - LangChain Nebius provider: <https://docs.langchain.com/oss/python/integrations/providers/nebius>
-- Nebius Token Factory: <https://studio.nebius.com/>
+- Nebius Token Factory: <https://tokenfactory.nebius.com/>
 - Tavily: <https://tavily.com/>

--- a/agents/nemotron-agents/env.example
+++ b/agents/nemotron-agents/env.example
@@ -1,2 +1,2 @@
-# Nebius Token Factory — https://studio.nebius.com/
+# Nebius Token Factory — https://tokenfactory.nebius.com/
 NEBIUS_API_KEY=your-nebius-api-key

--- a/workshops/deep-research-writing-agents-nebius-okahu/README.md
+++ b/workshops/deep-research-writing-agents-nebius-okahu/README.md
@@ -300,7 +300,7 @@ What's the most complex system you've encountered recently?
 | Python 3.12+ | `python --version` | `uv python install 3.12` or [python.org](https://www.python.org/downloads/) |
 | uv 0.7+ | `uv --version` | `curl -LsSf https://astral.sh/uv/install.sh \| sh` ([docs](https://docs.astral.sh/uv/getting-started/installation/)) |
 | GNU Make | `make --version` | Pre-installed on macOS/Linux. Windows: `choco install make` |
-| Nebius API Key | — | [studio.nebius.com](https://studio.nebius.com/) (required — text LLM calls) |
+| Nebius API Key | — | [tokenfactory.nebius.com](https://tokenfactory.nebius.com/) (required — text LLM calls) |
 | Exa API Key | — | [dashboard.exa.ai](https://dashboard.exa.ai/) (required — real-time search) |
 | Gemini API Key | — | [aistudio.google.com/apikey](https://aistudio.google.com/apikey) (required — image generation) |
 | Okahu account | — | [okahu.ai](https://www.okahu.ai/) (optional, for observability and eval traces) |

--- a/workshops/deep-research-writing-agents-nebius-okahu/implement_yourself/tasks/001-bootstrap-research-mcp-server.groomed.md
+++ b/workshops/deep-research-writing-agents-nebius-okahu/implement_yourself/tasks/001-bootstrap-research-mcp-server.groomed.md
@@ -33,7 +33,7 @@ Wire the boot path of the `deep-research` MCP server so that `make run-research-
 | `log_level` | `int` | `logging.INFO` (`LOG_LEVEL`) | Pydantic alias `LOG_LEVEL` |
 | `llm_model` | `str` | `"meta-llama/Llama-3.3-70B-Instruct"` | Default Nebius-hosted model |
 | `youtube_transcription_model` | `str` | `"meta-llama/Llama-3.3-70B-Instruct"` | Nebius model for transcript summarization |
-| `nebius_base_url` | `str` | `"https://api.studio.nebius.com/v1/"` | OpenAI-compatible Nebius base URL |
+| `nebius_base_url` | `str` | `"https://api.tokenfactory.nebius.com/v1/"` | OpenAI-compatible Nebius base URL |
 | `nebius_api_key` | `SecretStr` | required | Pydantic alias `NEBIUS_API_KEY` |
 | `exa_api_key` | `SecretStr` | required | Pydantic alias `EXA_API_KEY` |
 | `okahu_api_key` | `SecretStr \| None` | `None` | Alias `OKAHU_API_KEY`; reserved for #020 |

--- a/workshops/deep-research-writing-agents-nebius-okahu/implement_yourself/tasks/010-bootstrap-writing-mcp-server.groomed.md
+++ b/workshops/deep-research-writing-agents-nebius-okahu/implement_yourself/tasks/010-bootstrap-writing-mcp-server.groomed.md
@@ -35,7 +35,7 @@ Mirror the shape of the research server tightly — every layer (`routers/`, `to
 | `writer_model` | `str` | `"meta-llama/Llama-3.3-70B-Instruct"` | Nebius model used by `write_post` / `edit_post` |
 | `reviewer_model` | `str` | `"meta-llama/Llama-3.3-70B-Instruct"` | Nebius model used by `review_post` and the LLM judge |
 | `image_model` | `str` | `"gemini-2.5-flash-image"` | Used by `generate_image` (#015) |
-| `nebius_base_url` | `str` | `"https://api.studio.nebius.com/v1/"` | OpenAI-compatible Nebius base URL |
+| `nebius_base_url` | `str` | `"https://api.tokenfactory.nebius.com/v1/"` | OpenAI-compatible Nebius base URL |
 | `num_reviews` | `int` | `4` | Number of evaluator-optimizer iterations (#013) |
 | `nebius_api_key` | `SecretStr` | required | Alias `NEBIUS_API_KEY` |
 | `gemini_api_key` | `SecretStr` | required | Alias `GEMINI_API_KEY` for image generation |

--- a/workshops/deep-research-writing-agents-nebius-okahu/src/research/config/settings.py
+++ b/workshops/deep-research-writing-agents-nebius-okahu/src/research/config/settings.py
@@ -37,7 +37,7 @@ class Settings(BaseSettings):
         description="Nebius-hosted model for YouTube transcript summarization",
     )
     nebius_base_url: str = Field(
-        default="https://api.studio.nebius.com/v1/",
+        default="https://api.tokenfactory.nebius.com/v1/",
         alias="NEBIUS_BASE_URL",
         description="OpenAI-compatible Nebius API base URL",
     )

--- a/workshops/deep-research-writing-agents-nebius-okahu/src/writing/config/settings.py
+++ b/workshops/deep-research-writing-agents-nebius-okahu/src/writing/config/settings.py
@@ -42,7 +42,7 @@ class Settings(BaseSettings):
         description="Gemini image generation model",
     )
     nebius_base_url: str = Field(
-        default="https://api.studio.nebius.com/v1/",
+        default="https://api.tokenfactory.nebius.com/v1/",
         alias="NEBIUS_BASE_URL",
         description="OpenAI-compatible Nebius API base URL",
     )


### PR DESCRIPTION
Fixes #65.

The repo has standardized on `https://api.tokenfactory.nebius.com/v1/` (~50 occurrences), but 14 references still pointed at the legacy Studio domain — split inconsistently across `.ai` and `.com`.

## Runtime defaults (7)

These are the ones that matter: the affected examples were pointing at the wrong host out of the box.

| File | Was |
| --- | --- |
| `agents/langchain/customer-support-resolution-agent/main.py:107` | `api.studio.nebius.ai/v1/` |
| `agents/langchain/data-quality-ops-agent/main.py:138` | `api.studio.nebius.ai/v1/` |
| `agents/langchain/incident-response-agent/main.py:101` | `api.studio.nebius.ai/v1/` |
| `agents/langchain/vendor-risk-compliance-agent/main.py:100` | `api.studio.nebius.ai/v1/` |
| `agents/langchain/voice-agent-gradium-nebius-langchain/voice_pitch_coach/coach.py:62` | `api.studio.nebius.ai/v1/` |
| `workshops/.../src/research/config/settings.py:40` | `api.studio.nebius.com/v1/` |
| `workshops/.../src/writing/config/settings.py:45` | `api.studio.nebius.com/v1/` |

## Docs and env samples (7)

`agents/nemotron-agents/{README.md,env.example}`, `agents/langchain/deep-agent-example-1/{README.md,env.example}`, the workshop `README.md` prerequisites table, and the two `*.groomed.md` task specs.

The task specs document the expected `nebius_base_url` default, so they are updated alongside `settings.py` to keep the spec and the code in sync.

## Why this replacement

`https://api.tokenfactory.nebius.com/v1/` is what `insurance-claims-assistant/claims_assistant/config.py:23` and `rag/support-agent-weaviate/config.py:10` already use as their `NEBIUS_BASE_URL` default, and console links follow the `https://tokenfactory.nebius.com/` form used elsewhere in the repo.

## Verification

- `grep -rIn "studio\.nebius"` returns nothing.
- All seven touched Python files compile.
- No test or script asserts the old value — `NEBIUS_BASE_URL` remains overridable via env in every case, so anyone still on the old endpoint can set it explicitly.

Independent of #67; the two branches touch different lines of `agents/nemotron-agents/README.md` and merge cleanly in either order.
